### PR TITLE
vdpa/virtio: Didn't set msix if call fd is -1

### DIFF
--- a/drivers/common/virtio/version.map
+++ b/drivers/common/virtio/version.map
@@ -34,9 +34,11 @@ INTERNAL {
 	virtio_pci_dev_config_read;
 	virtio_pci_dev_config_write;
 	virtio_pci_dev_state_config_read;
+	virtio_pci_dev_state_config_write;
 	virtio_pci_dev_state_bar_copy;
 	virtio_pci_dev_state_size_get;
 	virtio_pci_dev_state_num_queue_set;
+	virtio_pci_dev_isr_get;
 
 	local: *;
 };

--- a/drivers/common/virtio/virtio.c
+++ b/drivers/common/virtio/virtio.c
@@ -772,6 +772,23 @@ virtio_pci_dev_state_config_read(struct virtio_pci_dev *vpdev, void *dst, int le
 }
 
 void
+virtio_pci_dev_state_config_write(struct virtio_pci_dev *vpdev, void *src, int length, void *state)
+{
+	struct virtio_hw *hw = &vpdev->hw;
+	struct virtio_dev_common_state *state_info = state;
+	uint16_t dev_cfg_len;
+
+	dev_cfg_len = hw->virtio_dev_sp_ops->get_dev_cfg_size();
+
+	if (length != dev_cfg_len) {
+		PMD_INIT_LOG(INFO, "vpdev %s write len %d != cfg len %d use min", VP_DEV_NAME(vpdev), length, dev_cfg_len);
+	}
+	rte_memcpy(state_info + 1, src, RTE_MIN(length, dev_cfg_len));
+
+	PMD_INIT_LOG(INFO, "vpdev %s dev cfg copy len: %d", VP_DEV_NAME(vpdev), RTE_MIN(length, dev_cfg_len));
+}
+
+void
 virtio_pci_dev_config_read(struct virtio_pci_dev *vpdev, size_t offset,
 		      void *dst, int length)
 {
@@ -790,8 +807,10 @@ virtio_pci_dev_config_write(struct virtio_pci_dev *vpdev, size_t offset,
 }
 
 uint8_t
-virtio_pci_dev_isr_get(struct virtio_hw *hw)
+virtio_pci_dev_isr_get(struct virtio_pci_dev *vpdev)
 {
+	struct virtio_hw *hw = &vpdev->hw;
+
 	return VIRTIO_OPS(hw)->get_isr(hw);
 }
 

--- a/drivers/common/virtio/virtio.h
+++ b/drivers/common/virtio/virtio.h
@@ -191,5 +191,4 @@ virtio_with_packed_queue(struct virtio_hw *hw)
 	return virtio_with_feature(hw, VIRTIO_F_RING_PACKED);
 }
 
-uint8_t virtio_pci_dev_isr_get(struct virtio_hw *hw);
 #endif /* _VIRTIO_H_ */

--- a/drivers/common/virtio/virtio_api.h
+++ b/drivers/common/virtio/virtio_api.h
@@ -108,10 +108,15 @@ void virtio_pci_dev_config_write(struct virtio_pci_dev *vpdev, size_t offset, co
 __rte_internal
 void virtio_pci_dev_state_config_read(struct virtio_pci_dev *vpdev, void *dst, int length, void *state);
 __rte_internal
+void virtio_pci_dev_state_config_write(struct virtio_pci_dev *vpdev, void *src, int length, void *state);
+__rte_internal
 int virtio_pci_dev_state_bar_copy(struct virtio_pci_dev *vpdev, void *state, int state_len);
 __rte_internal
 int virtio_pci_dev_state_size_get(struct virtio_pci_dev *vpdev);
 __rte_internal
 void virtio_pci_dev_state_num_queue_set(struct virtio_pci_dev *vpdev);
+__rte_internal
+uint8_t virtio_pci_dev_isr_get(struct virtio_pci_dev *vpdev);
+
 
 #endif /* _VIRTIO_API_H_ */

--- a/drivers/vdpa/virtio/rte_vf_rpc.c
+++ b/drivers/vdpa/virtio/rte_vf_rpc.c
@@ -36,12 +36,24 @@ rte_vdpa_vf_dev_add(const char *vf_name, struct vdpa_vf_params *vf_params __rte_
 	char args[RTE_DEV_NAME_MAX_LEN];
 	snprintf(args, RTE_DEV_NAME_MAX_LEN, "%s=%s", VIRTIO_ARG_VDPA, VIRTIO_ARG_VDPA_VALUE_VF);
 
+	if (!vf_name)
+		return -EINVAL;
+
+	if(virtio_vdpa_find_priv_resource_by_name(vf_name))
+		return -EEXIST;
+
 	return rte_eal_hotplug_add("pci", vf_name, args);
 }
 
 int
 rte_vdpa_vf_dev_remove(const char *vf_name)
 {
+	if (!vf_name)
+		return -EINVAL;
+
+	if(!virtio_vdpa_find_priv_resource_by_name(vf_name))
+		return -ENODEV;
+
 	return rte_eal_hotplug_remove("pci", vf_name);
 }
 

--- a/drivers/vdpa/virtio/rte_vf_rpc.c
+++ b/drivers/vdpa/virtio/rte_vf_rpc.c
@@ -12,6 +12,7 @@
 #include "virtio_api.h"
 #include "virtio_lm.h"
 #include "virtio_vdpa.h"
+#include <rte_vhost.h>
 
 extern int virtio_vdpa_logtype;
 #define RPC_LOG(level, fmt, args...) \
@@ -148,6 +149,7 @@ rte_vdpa_vf_dev_debug(const char *vf_name,
 	uint64_t range_length;
 	struct virtio_sge sge;
 	uint32_t unit = 1;
+	uint16_t num_vr;
 	int ret, i;
 
 	if (!vf_name || !vf_debug_info)
@@ -214,7 +216,9 @@ rte_vdpa_vf_dev_debug(const char *vf_name,
 				RPC_LOG(ERR, "<<<<Dity map get fail, should start log first>>>>");
 				return -EINVAL;
 			}
-			for (i = 0; i < vf_priv->nr_virtqs; i++) {
+
+			num_vr = rte_vhost_get_vring_num(vf_priv->vid);
+			for (i = 0; i < num_vr; i++) {
 				uint64_t dirty_addr;
 				uint32_t dirty_len;
 				ret = 0;

--- a/drivers/vdpa/virtio/virtio_vdpa.h
+++ b/drivers/vdpa/virtio/virtio_vdpa.h
@@ -25,11 +25,6 @@ struct virtio_vdpa_vring_info {
 
 #define VIRTIO_VDPA_DRIVER_NAME vdpa_virtio
 
-struct virtio_vdpa_device_callback {
-	void (*vhost_feature_get)(uint64_t *features);
-	int (*dirty_desc_get)(int vid, int qix, uint64_t *desc_addr, uint32_t *write_len);
-};
-
 struct virtio_vdpa_priv {
 	TAILQ_ENTRY(virtio_vdpa_priv) next;
 	const struct rte_memzone *vdpa_dp_map;
@@ -55,9 +50,19 @@ struct virtio_vdpa_priv {
 	struct virtio_vdpa_vring_info **vrings;
 	uint16_t hw_nr_virtqs; /* Number of vq device supported */
 	bool configured;
+	bool dev_conf_read;
 };
 
 #define VIRTIO_VDPA_REMOTE_STATE_DEFAULT_SIZE 8192
+#define VIRTIO_VDPA_INTR_RETRIES_USEC 1000
+#define VIRTIO_VDPA_INTR_RETRIES 256
+
+struct virtio_vdpa_device_callback {
+	void (*vhost_feature_get)(uint64_t *features);
+	int (*dirty_desc_get)(int vid, int qix, uint64_t *desc_addr, uint32_t *write_len);
+	int (*reg_dev_intr)(struct virtio_vdpa_priv* priv);
+	int (*unreg_dev_intr)(struct virtio_vdpa_priv* priv);
+};
 
 int virtio_vdpa_dev_pf_filter_dump(struct vdpa_vf_params *vf_info, int max_vf_num, struct virtio_vdpa_pf_priv *pf_priv);
 int virtio_vdpa_dev_vf_filter_dump(const char *vf_name, struct vdpa_vf_params *vf_info);

--- a/drivers/vdpa/virtio/virtio_vdpa.h
+++ b/drivers/vdpa/virtio/virtio_vdpa.h
@@ -53,7 +53,6 @@ struct virtio_vdpa_priv {
 	int dev_work_flag;
 	uint64_t guest_features;
 	struct virtio_vdpa_vring_info **vrings;
-	uint16_t nr_virtqs;   /* Number of vq vhost enabled */
 	uint16_t hw_nr_virtqs; /* Number of vq device supported */
 	bool configured;
 };

--- a/drivers/vdpa/virtio/virtio_vdpa_net.c
+++ b/drivers/vdpa/virtio/virtio_vdpa_net.c
@@ -50,5 +50,7 @@ virtio_vdpa_net_dirty_desc_get(int vid, int qix, uint64_t *desc_addr, uint32_t *
 struct virtio_vdpa_device_callback virtio_vdpa_net_callback = {
 	.vhost_feature_get = virtio_vdpa_net_vhost_feature_get,
 	.dirty_desc_get = virtio_vdpa_net_dirty_desc_get,
+	.reg_dev_intr = NULL,
+	.unreg_dev_intr = NULL,
 };
 


### PR DESCRIPTION
1 Msix is 0xFFFF when call fd is -1
2 Remove nr_vq, get nr_vq through vhost API

Signed-off-by: Kailiang Zhou <kailiangz@nvidia.com>