### PR TITLE
vdpa/vritio: Move VDPA device destroy before vhost connect close

### DIFF
--- a/drivers/vdpa/virtio/virtio_vdpa.c
+++ b/drivers/vdpa/virtio/virtio_vdpa.c
@@ -177,14 +177,16 @@ virtio_vdpa_vqs_max_get(struct rte_vdpa_device *vdev, uint32_t *queue_num)
 {
 	struct virtio_vdpa_priv *priv =
 		virtio_vdpa_find_priv_resource_by_vdev(vdev);
+	int unit;
 
 	if (priv == NULL) {
 		DRV_LOG(ERR, "Invalid vDPA device: %s", vdev->device->name);
 		return -ENODEV;
 	}
 
-	*queue_num = priv->hw_nr_virtqs;
-	DRV_LOG(DEBUG, "Vid %d queue num is %d", priv->vid, *queue_num);
+	unit = priv->dev_ops->vdpa_queue_num_unit_get();
+	*queue_num = priv->hw_nr_virtqs / unit;
+	DRV_LOG(DEBUG, "Vid %d queue num is %d unit %d", priv->vid, *queue_num, unit);
 	return 0;
 }
 

--- a/drivers/vdpa/virtio/virtio_vdpa.c
+++ b/drivers/vdpa/virtio/virtio_vdpa.c
@@ -972,7 +972,6 @@ virtio_vdpa_dev_close(int vid)
 		return ret;
 	}
 
-	virtio_pci_dev_state_dump(priv->vpdev ,priv->state_mz_remote->addr, res.pending_bytes);
 	num_vr = rte_vhost_get_vring_num(vid);
 	tmp_hw_idx = rte_zmalloc(NULL, num_vr * sizeof(struct virtio_dev_run_state_info), 0);
 
@@ -1094,11 +1093,10 @@ virtio_vdpa_dev_config(int vid)
 													VIRTIO_CONFIG_STATUS_FEATURES_OK |
 													VIRTIO_CONFIG_STATUS_DRIVER_OK);
 
-	virtio_pci_dev_state_dump(priv->vpdev , priv->state_mz->addr, priv->state_size);
-
 	ret = virtio_vdpa_cmd_restore_state(priv->pf_priv, priv->vf_id, 0, priv->state_size, priv->state_mz->iova);
 	if (ret) {
 		DRV_LOG(ERR, "%s vfid %d failed restore state ret:%d", vdev->device->name, priv->vf_id, ret);
+		virtio_pci_dev_state_dump(priv->vpdev , priv->state_mz->addr, priv->state_size);
 		rte_errno = rte_errno ? rte_errno : EINVAL;
 		return -rte_errno;
 	}
@@ -1646,8 +1644,6 @@ virtio_vdpa_dev_probe(struct rte_pci_driver *pci_drv __rte_unused,
 		rte_errno = rte_errno ? rte_errno : EINVAL;
 		goto error;
 	}
-
-	virtio_pci_dev_state_dump(priv->vpdev, priv->state_mz->addr, state_len);
 
 	ret = virtio_vdpa_cmd_set_status(priv->pf_priv, priv->vf_id, VIRTIO_S_QUIESCED);
 	if (ret) {

--- a/drivers/vdpa/virtio/virtio_vdpa.h
+++ b/drivers/vdpa/virtio/virtio_vdpa.h
@@ -62,6 +62,7 @@ struct virtio_vdpa_device_callback {
 	int (*dirty_desc_get)(int vid, int qix, uint64_t *desc_addr, uint32_t *write_len);
 	int (*reg_dev_intr)(struct virtio_vdpa_priv* priv);
 	int (*unreg_dev_intr)(struct virtio_vdpa_priv* priv);
+	int (*vdpa_queue_num_unit_get)(void);
 };
 
 int virtio_vdpa_dev_pf_filter_dump(struct vdpa_vf_params *vf_info, int max_vf_num, struct virtio_vdpa_pf_priv *pf_priv);

--- a/drivers/vdpa/virtio/virtio_vdpa_blk.c
+++ b/drivers/vdpa/virtio/virtio_vdpa_blk.c
@@ -24,6 +24,8 @@ extern int virtio_vdpa_logtype;
 	rte_log(RTE_LOG_ ## level, virtio_vdpa_logtype, \
 		"VIRTIO VDPA BLK %s(): " fmt "\n", __func__, ##args)
 
+#define VIRTIO_VDPA_BLK_QUEUE_NUM_UNIT 1
+
 static void
 virtio_vdpa_blk_vhost_feature_get(uint64_t *features)
 {
@@ -155,10 +157,17 @@ virtio_vdpa_blk_reg_dev_interrupt(struct virtio_vdpa_priv *priv)
 	return 0;
 }
 
+static int
+virtio_vdpa_blk_queue_num_unit_get(void)
+{
+	return VIRTIO_VDPA_BLK_QUEUE_NUM_UNIT;
+}
+
 struct virtio_vdpa_device_callback virtio_vdpa_blk_callback = {
 	.vhost_feature_get = virtio_vdpa_blk_vhost_feature_get,
 	.dirty_desc_get = virtio_vdpa_blk_dirty_desc_get,
 	.reg_dev_intr = virtio_vdpa_blk_reg_dev_interrupt,
 	.unreg_dev_intr = virtio_vdpa_blk_unreg_dev_interrupt,
+	.vdpa_queue_num_unit_get = virtio_vdpa_blk_queue_num_unit_get,
 };
 

--- a/drivers/vdpa/virtio/virtio_vdpa_net.c
+++ b/drivers/vdpa/virtio/virtio_vdpa_net.c
@@ -21,6 +21,8 @@ extern int virtio_vdpa_logtype;
 	rte_log(RTE_LOG_ ## level, virtio_vdpa_logtype, \
 		"VIRTIO VDPA NET %s(): " fmt "\n", __func__, ##args)
 
+#define VIRTIO_VDPA_NET_QUEUE_NUM_UNIT 2
+
 static void
 virtio_vdpa_net_vhost_feature_get(uint64_t *features)
 {
@@ -46,11 +48,17 @@ virtio_vdpa_net_dirty_desc_get(int vid, int qix, uint64_t *desc_addr, uint32_t *
 
 	return 0;
 }
+static int
+virtio_vdpa_net_queue_num_unit_get(void)
+{
+	return VIRTIO_VDPA_NET_QUEUE_NUM_UNIT;
+}
 
 struct virtio_vdpa_device_callback virtio_vdpa_net_callback = {
 	.vhost_feature_get = virtio_vdpa_net_vhost_feature_get,
 	.dirty_desc_get = virtio_vdpa_net_dirty_desc_get,
 	.reg_dev_intr = NULL,
 	.unreg_dev_intr = NULL,
+	.vdpa_queue_num_unit_get = virtio_vdpa_net_queue_num_unit_get,
 };
 


### PR DESCRIPTION
VDPA device should come before vhost conect close as kick fd will freed when connect close, so, DPDK will unreg kick fd first, then close connect

Signed-off-by: Kailiang Zhou <kailiangz@nvidia.com>