### PR TITLE
app/vfe-vdpa: fix vdpa process quit caused by rpc client abort

### DIFF
--- a/app/vfe-vdpa/main.c
+++ b/app/vfe-vdpa/main.c
@@ -731,6 +731,7 @@ main(int argc, char *argv[])
 	sigemptyset(&set);
 	sigaddset(&set, SIGINT);
 	sigaddset(&set, SIGTERM);
+	signal(SIGPIPE, SIG_IGN);
 	ret = pthread_sigmask(SIG_BLOCK, &set, NULL);
 	if (ret != 0)
 		printf("Set sig mask fail");

--- a/app/vfe-vdpa/vhostmgmt
+++ b/app/vfe-vdpa/vhostmgmt
@@ -34,7 +34,7 @@ class JsonRpcSnapException(Exception):
 class JsonRpcVirtnetClient(object):
     decoder = json.JSONDecoder()
 
-    def __init__(self, address, port, timeout=60.0):
+    def __init__(self, address, port, timeout=125.0):
         self.sock = None
         self._request_id = 0
         self.timeout = timeout


### PR DESCRIPTION
Use ctrl+c to quit rpc client (vhostmgmt), vDPA process will also quit because receiving SIGPIPE.

Ignore SIGPIPE and set rpc client timeout to 125s(waiting VF reset).

RM: 3417752