### PR TITLE
vdpa/virtio: skip save if restore fail

### DIFF
--- a/drivers/vdpa/virtio/virtio_vdpa.c
+++ b/drivers/vdpa/virtio/virtio_vdpa.c
@@ -892,6 +892,10 @@ virtio_vdpa_dev_close(int vid)
 		DRV_LOG(ERR, "Invalid vDPA device: %s", vdev->device->name);
 		return -ENODEV;
 	}
+	if (!priv->configured) {
+		DRV_LOG(ERR, "vDPA device: %s isn't configured.", vdev->device->name);
+		return -EINVAL;
+	}
 
 	priv->configured = false;
 


### PR DESCRIPTION
If device restore fail in virtio_vdpa_dev_config, skip device save in virtio_vdpa_dev_close to avoid snap side crash.

RM: 3546755