### PR TITLE
vdpa/virtio: Fix unwanted dirty page start track

### DIFF
--- a/drivers/vdpa/virtio/virtio_vdpa.c
+++ b/drivers/vdpa/virtio/virtio_vdpa.c
@@ -792,7 +792,7 @@ virtio_vdpa_features_set(int vid)
 					priv->vdev->device->name);
 		return ret;
 	}
-	if (RTE_VHOST_NEED_LOG(features)) {
+	if (RTE_VHOST_NEED_LOG(features) && priv->configured) {
 		ret = rte_vhost_get_log_base(vid, &log_base, &log_size);
 		if (ret) {
 			DRV_LOG(ERR, "%s failed to get log base",


### PR DESCRIPTION
For LM failure, qemu will start device again on source machine. Seems VHOST_F_LOG_ALL bit is still valid for this kind of device restart.

Skip dirty page start track, if device isn't configured.