### PR TITLE
vhost: fix remove vf reconnect crash

### DIFF
--- a/lib/vhost/socket.c
+++ b/lib/vhost/socket.c
@@ -1053,6 +1053,8 @@ again:
 		if (vsocket->is_server) {
 			close(vsocket->socket_fd);
 			unlink(path);
+		} else if (vsocket->reconnect) {
+			vhost_user_remove_reconnect(vsocket);
 		}
 
 		pthread_mutex_destroy(&vsocket->conn_mutex);


### PR DESCRIPTION
In rte_vhost_driver_unregister which is called from vdpa-rpc thread, vsocket should be removed from reconn_list again after remove vsocket from conn_list. Because vhost_user_read_cb which is called in vhost-events thread can add vsocket to reconn_list again.

When qemu close domain socket server, vhost_user_read_cb will be called to clean up vhost device.

vsocket->path is NULL

RM: 3585558