### PR TITLE
vdpa/virtio: Fix virtio_vdpa_virtq_doorbell_relay_disable crash

### DIFF
--- a/drivers/vdpa/virtio/virtio_vdpa.h
+++ b/drivers/vdpa/virtio/virtio_vdpa.h
@@ -19,6 +19,7 @@ struct virtio_vdpa_vring_info {
 	uint16_t index;
 	uint8_t notifier_state;
 	bool enable;
+	bool vector_enable;
 	struct rte_intr_handle *intr_handle;
 	struct virtio_vdpa_priv *priv;
 };


### PR DESCRIPTION
When MSIX configured less then queue number, quit testpmd in VM, cause vDPA crash.

	#3  0x00007fbc8421b489 in _int_free () from /lib64/libc.so.6
	#4  0x0000000001a471c5 in virtio_vdpa_virtq_doorbell_relay_disable (vq_idx=vq_idx@entry=11, priv=<optimized out>, priv=<optimized out>) at ../drivers/vdpa/virtio/virtio_vdpa.c:349
	#5  0x0000000001a47275 in virtio_vdpa_virtq_disable () at ../drivers/vdpa/virtio/virtio_vdpa.c:413
	#6  0x0000000001a47a5a in virtio_vdpa_vring_state_set () at ../drivers/vdpa/virtio/virtio_vdpa.c:588
	#7  0x00000000005ad8af in vhost_user_notify_queue_state (dev=0x17ffcd000, index=11, enable=0) at ../lib/vhost/vhost_user.c:283
	#8  0x00000000005b0414 in vhost_user_msg_handler (vid=<optimized out>, fd=<optimized out>) at ../lib/vhost/vhost_user.c:3164
	#9  0x00000000012f812f in vhost_user_read_cb () at ../lib/vhost/socket.c:310

When callfd == -1, virtio_pci_dev_interrupt_enable is skipped. But in virtio_vdpa_virtq_disable, no such check to skip virtio_pci_dev_interrupt_disable. virtio_vdpa_virtq_disable return error without changing queue state to disable. Double free is caused by this wrong queue state.

The fix is to add/check vector_enable variable for virtio_pci_dev_interrupt_disable. And remove error return in virtio_vdpa_virtq_disable.

RM: 3587409