### PR TITLE
vdpa/virtio: Fix add VF crash without adding PF first

### DIFF
--- a/drivers/common/virtio/virtio.c
+++ b/drivers/common/virtio/virtio.c
@@ -93,7 +93,7 @@ virtio_pci_dev_queues_free(struct virtio_pci_dev *vpdev, uint16_t nr_vq)
 	struct virtqueue *vq;
 	uint16_t i;
 
-	if (hw->vqs == NULL)
+	if (hw == NULL || hw->vqs == NULL)
 		return;
 
 	for (i = 0; i < nr_vq; i++) {

--- a/drivers/vdpa/virtio/virtio_vdpa.c
+++ b/drivers/vdpa/virtio/virtio_vdpa.c
@@ -1465,7 +1465,7 @@ virtio_vdpa_dev_do_remove(struct rte_pci_device *pci_dev, struct virtio_vdpa_pri
 		DRV_LOG(ERR, "%s is dev close work had err", pci_dev->name);
 	}
 
-	if (priv->dev_ops->unreg_dev_intr) {
+	if (priv->dev_ops && priv->dev_ops->unreg_dev_intr) {
 		ret = virtio_pci_dev_interrupt_disable(priv->vpdev, 0);
 		if (ret) {
 			DRV_LOG(ERR, "%s error disabling virtio dev interrupts: %d (%s)",


### PR DESCRIPTION
Need to add more valid pointer check in virtio_vdpa_dev_do_remove while virtio_vdpa_dev_probe fail.

This case is reported by adding VF without adding PF first.

RM: 3633304