### PR TITLE
vdpa/virtio: Fix wrong set vring base(used index)

### DIFF
--- a/drivers/vdpa/virtio/virtio_vdpa.c
+++ b/drivers/vdpa/virtio/virtio_vdpa.c
@@ -411,6 +411,16 @@ virtio_vdpa_virtq_disable(struct virtio_vdpa_priv *priv, int vq_idx)
 	struct rte_vhost_vring vq;
 	int ret;
 
+    if (priv->configured) {
+		uint64_t features;
+		virtio_pci_dev_features_get(priv->vpdev, &features);
+		if (!(features & VIRTIO_F_RING_RESET)) {
+			DRV_LOG(WARNING, "%s can't disable queue after driver ok without queue reset support",
+					priv->vdev->device->name);
+			return 0;
+		}
+	}
+
 	ret = virtio_vdpa_virtq_doorbell_relay_disable(priv, vq_idx);
 	if (ret) {
 		DRV_LOG(ERR, "%s doorbell relay disable failed ret:%d",


### PR DESCRIPTION
With qemu 7.2 commits:

02b61f38d3 ("hw/virtio: incorporate backend features in features") 4daa5054c5 ("enable vrings in vhost_dev_start() for vhost-user devices")

vhost-user-blk frontend now will send VHOST_USER_SET_VRING_ENABLE(0) before VHOST_USER_GET_VRING_BASE.

blk backend doesn't support VIRTIO_F_RING_RESET, so ignore this queue disable if no device feature VIRTIO_F_RING_RESET.

RM: 3635307