### PR TITLE
vdpa/virtio: fix mem hotplug wrong queue disable

### DIFF
--- a/drivers/vdpa/virtio/virtio_vdpa.h
+++ b/drivers/vdpa/virtio/virtio_vdpa.h
@@ -19,7 +19,6 @@ struct virtio_vdpa_vring_info {
 	uint16_t index;
 	uint8_t notifier_state;
 	bool enable;
-	bool vector_enable;
 	struct rte_intr_handle *intr_handle;
 	struct virtio_vdpa_priv *priv;
 };


### PR DESCRIPTION
For QEMU hotplug memory case, vhost framework will call virtio_vdpa_dev_close, virtio_vdpa_dev_set_mem_table, then virtio_vdpa_dev_config.

Remove wrong queue disable in virtio_vdpa_dev_close to virtio_vdpa_dev_cleanup. Normally GET_VRING_BASE message will disable the queue explicitly.