### PR TITLE
vhost: reduce memory footprint when IOMMU is disabled

### DIFF
--- a/lib/vhost/socket.c
+++ b/lib/vhost/socket.c
@@ -227,7 +227,7 @@ vhost_user_add_connection(int fd, struct vhost_user_socket *vsocket)
 	vhost_set_ifname(vid, vsocket->path, size);
 
 	vhost_setup_virtio_net(vid, vsocket->use_builtin_virtio_net,
-		vsocket->net_compliant_ol_flags);
+		vsocket->net_compliant_ol_flags, vsocket->iommu_support);
 
 	vhost_attach_vdpa_device(vid, vsocket->vdpa_dev);
 
@@ -863,6 +863,7 @@ rte_vhost_driver_register(const char *path, uint64_t flags)
 	vsocket->linearbuf = flags & RTE_VHOST_USER_LINEARBUF_SUPPORT;
 	vsocket->async_copy = flags & RTE_VHOST_USER_ASYNC_COPY;
 	vsocket->net_compliant_ol_flags = flags & RTE_VHOST_USER_NET_COMPLIANT_OL_FLAGS;
+	vsocket->iommu_support = flags & RTE_VHOST_USER_IOMMU_SUPPORT;
 
 	if (vsocket->async_copy &&
 		(flags & (RTE_VHOST_USER_IOMMU_SUPPORT |

--- a/lib/vhost/vhost.c
+++ b/lib/vhost/vhost.c
@@ -755,7 +755,7 @@ vhost_set_ifname(int vid, const char *if_name, unsigned int if_len)
 }
 
 void
-vhost_setup_virtio_net(int vid, bool enable, bool compliant_ol_flags)
+vhost_setup_virtio_net(int vid, bool enable, bool compliant_ol_flags, bool support_iommu)
 {
 	struct virtio_net *dev = get_device(vid);
 
@@ -770,6 +770,10 @@ vhost_setup_virtio_net(int vid, bool enable, bool compliant_ol_flags)
 		dev->flags |= VIRTIO_DEV_LEGACY_OL_FLAGS;
 	else
 		dev->flags &= ~VIRTIO_DEV_LEGACY_OL_FLAGS;
+	if (support_iommu)
+		dev->flags |= VIRTIO_DEV_SUPPORT_IOMMU;
+	else
+		dev->flags &= ~VIRTIO_DEV_SUPPORT_IOMMU;
 }
 
 void

--- a/lib/vhost/vhost.h
+++ b/lib/vhost/vhost.h
@@ -37,6 +37,10 @@
 #define VIRTIO_DEV_FEATURES_FAILED ((uint32_t)1 << 4)
 /* Used to indicate that the virtio_net tx code should fill TX ol_flags */
 #define VIRTIO_DEV_LEGACY_OL_FLAGS ((uint32_t)1 << 5)
+/*  Used to indicate the application has requested statistics collection */
+#define VIRTIO_DEV_STATS_ENABLED ((uint32_t)1 << 6)
+/*  Used to indicate the application has requested iommu support */
+#define VIRTIO_DEV_SUPPORT_IOMMU ((uint32_t)1 << 7)
 
 /* Backend value set by guest. */
 #define VIRTIO_DEV_STOPPED -1
@@ -783,7 +787,7 @@ int alloc_vring_queue(struct virtio_net *dev, uint32_t vring_idx);
 void vhost_attach_vdpa_device(int vid, struct rte_vdpa_device *dev);
 
 void vhost_set_ifname(int, const char *if_name, unsigned int if_len);
-void vhost_setup_virtio_net(int vid, bool enable, bool legacy_ol_flags);
+void vhost_setup_virtio_net(int vid, bool enable, bool legacy_ol_flags, bool support_iommu);
 void vhost_enable_extbuf(int vid);
 void vhost_enable_linearbuf(int vid);
 int vhost_enable_guest_notification(struct virtio_net *dev,


### PR DESCRIPTION
If an application does not request IOMMU support, we can avoid allocating a IOMMU pool.

This saves 112kB (IOTLB_CACHE_SIZE * sizeof(struct vhost_iotlb_entry)) per vq.


Reviewed-by: Chenbo Xia <chenbo.xia@intel.com>