### PR TITLE
vdpa/virtio: fix blk crash at eal_intr_thread_main

### DIFF
--- a/drivers/vdpa/virtio/virtio_vdpa.c
+++ b/drivers/vdpa/virtio/virtio_vdpa.c
@@ -419,6 +419,9 @@ virtio_vdpa_virtq_disable(struct virtio_vdpa_priv *priv, int vq_idx)
 		if (!(features & VIRTIO_F_RING_RESET)) {
 			DRV_LOG(WARNING, "%s can't disable queue after driver ok without queue reset support",
 					priv->vdev->device->name);
+			// Handle blk special case SET_VRING_ENABLE(0) before GET_VRING_BASE
+			virtio_vdpa_virtq_doorbell_relay_disable(priv, vq_idx);
+			virtio_pci_dev_interrupt_disable(priv->vpdev, vq_idx + 1);
 			return 0;
 		}
 	}


### PR DESCRIPTION
Shutdown multiple blk device, dpdk crash:

	VHOST_CONFIG: (/tmp/sock-blk-10) vhost peer closed
	PANIC in eal_intr_thread_main():
	Error adding fd 589 epoll_ctl, Bad file descriptor
	5: [/lib64/libc.so.6(clone+0x6d) [0x7ffff5a8cead]]
	4: [/lib64/libpthread.so.0(+0x7dd5) [0x7ffff5d63dd5]]
	3: [/root/dpdk-vhost-vfe/build/app/dpdk-vfe-vdpa() [0x137a711]]
	2: [/root/dpdk-vhost-vfe/build/app/dpdk-vfe-vdpa(__rte_panic+0xba) [0x5ab12d]]
	1: [/root/dpdk-vhost-vfe/build/app/dpdk-vfe-vdpa(rte_dump_stack+0x1a) [0x1377faa]]

kickfd/callfd is closed in vhost_user_get_vring_base, virtio_vdpa_virtq_doorbell_relay_disable should be called in or before virtio_vdpa_dev_close.

Fixes: 92535c43aa ("vdpa/virtio: Fix wrong set vring base(used index)")
Fixes: 4f778ec741 ("vdpa/virtio: fix mem hotplug wrong queue disable")

RM: 3669299