### PR TITLE
vdpa/virtio: replace doorbell relay with notifier

### DIFF
--- a/drivers/common/virtio/version.map
+++ b/drivers/common/virtio/version.map
@@ -24,6 +24,7 @@ INTERNAL {
 	virtio_pci_dev_state_queue_set;
 	virtio_pci_dev_state_queue_del;
 	virtio_pci_dev_state_interrupt_enable;
+	virtio_pci_dev_state_interrupt_enable_only;
 	virtio_pci_dev_state_interrupt_disable;
 	virtio_pci_dev_state_dev_status_set;
 	virtio_pci_dev_state_dump;

--- a/drivers/common/virtio/virtio.c
+++ b/drivers/common/virtio/virtio.c
@@ -553,6 +553,23 @@ virtio_pci_dev_interrupts_free(struct virtio_pci_dev *vpdev)
 }
 
 int
+virtio_pci_dev_state_interrupt_enable_only(struct virtio_pci_dev *vpdev, int vec, void *state)
+{
+	struct virtio_hw *hw = &vpdev->hw;
+	struct virtio_dev_queue_info *q_info;
+	struct virtio_dev_common_state *state_info;
+
+	if (vec == 0) {
+		state_info = state;
+		state_info->common_cfg.msix_config = 0;
+	} else {
+		q_info = hw->virtio_dev_sp_ops->get_queue_offset(state);
+		q_info[vec-1].q_cfg.queue_msix_vector = rte_cpu_to_le_16(vec);
+	}
+	return 0;
+}
+
+int
 virtio_pci_dev_state_interrupt_enable(struct virtio_pci_dev *vpdev, int fd, int vec, void *state)
 {
 	struct virtio_hw *hw = &vpdev->hw;

--- a/drivers/common/virtio/virtio_api.h
+++ b/drivers/common/virtio/virtio_api.h
@@ -88,6 +88,8 @@ void virtio_pci_dev_state_queue_del(struct virtio_pci_dev *vpdev, uint16_t qid, 
 __rte_internal
 int virtio_pci_dev_state_interrupt_enable(struct virtio_pci_dev *vpdev, int fd, int vec, void *state);
 __rte_internal
+int virtio_pci_dev_state_interrupt_enable_only(struct virtio_pci_dev *vpdev, int vec, void *state);
+__rte_internal
 int virtio_pci_dev_state_interrupt_disable(struct virtio_pci_dev *vpdev, int vec, void *state);
 __rte_internal
 int virtio_pci_dev_interrupt_enable(struct virtio_pci_dev *vpdev, int fd, int vec);

--- a/drivers/vdpa/virtio/virtio_vdpa.c
+++ b/drivers/vdpa/virtio/virtio_vdpa.c
@@ -1352,6 +1352,12 @@ virtio_vdpa_dev_presetup_done(int vid)
 			rte_errno = rte_errno ? rte_errno : EINVAL;
 			return -rte_errno;
 		}
+		ret = virtio_pci_dev_state_interrupt_enable_only(priv->vpdev, i + 1, priv->state_mz->addr);
+		if (ret) {
+			DRV_LOG(ERR, "%s error set interrupt map in pre-config ret:%d", vdev->device->name, ret);
+			rte_errno = rte_errno ? rte_errno : EINVAL;
+			return -rte_errno;
+		}
 	}
 
 	virtio_pci_dev_state_dev_status_set(priv->state_mz->addr, VIRTIO_CONFIG_STATUS_ACK |

--- a/drivers/vdpa/virtio/virtio_vdpa.h
+++ b/drivers/vdpa/virtio/virtio_vdpa.h
@@ -6,9 +6,9 @@
 #define _VIRTIO_VDPA_H_
 
 enum {
-	VIRTIO_VDPA_NOTIFIER_STATE_DISABLED,
-	VIRTIO_VDPA_NOTIFIER_STATE_ENABLED,
-	VIRTIO_VDPA_NOTIFIER_STATE_ERR
+	VIRTIO_VDPA_NOTIFIER_RELAY_DISABLED,
+	VIRTIO_VDPA_NOTIFIER_RELAY_ENABLED,
+	VIRTIO_VDPA_NOTIFIER_RELAY_ERR
 };
 
 struct virtio_vdpa_iommu_domain {
@@ -64,6 +64,11 @@ struct virtio_vdpa_priv {
 	bool configured;
 	bool dev_conf_read;
 	bool mem_tbl_set;
+};
+
+struct virtio_vdpa_notifier_work {
+	struct virtio_vdpa_priv *priv;
+	uint16_t vq_idx;
 };
 
 #define VIRTIO_VDPA_REMOTE_STATE_DEFAULT_SIZE 8192


### PR DESCRIPTION
Doorbell relay is used before, but it is time consuming. Use notifier instead and use DPDK work to do notify because we can't wait when we process vhost msg, otherwise, deadlock will happend, so, use work thread to finish the job