### PR TITLE
app/vfe-vdpa: Remove GUEST_ANNOUNCE feature when set

### DIFF
--- a/drivers/vdpa/virtio/virtio_vdpa.c
+++ b/drivers/vdpa/virtio/virtio_vdpa.c
@@ -1112,6 +1112,9 @@ virtio_vdpa_features_set(int vid)
 	/* TO_DO: check why --- */
 	features |= (1ULL << VIRTIO_F_IOMMU_PLATFORM);
 	features |= (1ULL << VIRTIO_F_RING_RESET);
+	if (priv->dev_ops->set_vdpa_feature)
+		priv->dev_ops->set_vdpa_feature(&features);
+
 	if (priv->configured)
 		DRV_LOG(ERR, "%s vid %d set feature after driver ok, only when live migration", priv->vdev->device->name, vid);
 	else

--- a/drivers/vdpa/virtio/virtio_vdpa.h
+++ b/drivers/vdpa/virtio/virtio_vdpa.h
@@ -102,6 +102,7 @@ struct virtio_vdpa_device_callback {
 	int (*unreg_dev_intr)(struct virtio_vdpa_priv* priv);
 	int (*vdpa_queue_num_unit_get)(void);
 	void (*add_vdpa_feature)(uint64_t *features);
+	void (*set_vdpa_feature)(uint64_t *features);
 };
 
 int virtio_vdpa_dev_pf_filter_dump(struct vdpa_vf_params *vf_info, int max_vf_num, struct virtio_vdpa_pf_priv *pf_priv);

--- a/drivers/vdpa/virtio/virtio_vdpa_blk.c
+++ b/drivers/vdpa/virtio/virtio_vdpa_blk.c
@@ -171,5 +171,6 @@ struct virtio_vdpa_device_callback virtio_vdpa_blk_callback = {
 	.unreg_dev_intr = virtio_vdpa_blk_unreg_dev_interrupt,
 	.vdpa_queue_num_unit_get = virtio_vdpa_blk_queue_num_unit_get,
 	.add_vdpa_feature = NULL,
+	.set_vdpa_feature = NULL,
 };
 

--- a/drivers/vdpa/virtio/virtio_vdpa_net.c
+++ b/drivers/vdpa/virtio/virtio_vdpa_net.c
@@ -56,9 +56,15 @@ virtio_vdpa_net_queue_num_unit_get(void)
 }
 
 static void
-virtio_vdpa_net_add_vdap_feature(uint64_t *features)
+virtio_vdpa_net_add_vdpa_feature(uint64_t *features)
 {
 	*features |= (1ULL << VIRTIO_NET_F_GUEST_ANNOUNCE);
+}
+
+static void
+virtio_vdpa_net_set_vdpa_feature(uint64_t *features)
+{
+	*features &= (~(1ULL << VIRTIO_NET_F_GUEST_ANNOUNCE));
 }
 
 struct virtio_vdpa_device_callback virtio_vdpa_net_callback = {
@@ -67,6 +73,7 @@ struct virtio_vdpa_device_callback virtio_vdpa_net_callback = {
 	.reg_dev_intr = NULL,
 	.unreg_dev_intr = NULL,
 	.vdpa_queue_num_unit_get = virtio_vdpa_net_queue_num_unit_get,
-	.add_vdpa_feature = virtio_vdpa_net_add_vdap_feature,
+	.add_vdpa_feature = virtio_vdpa_net_add_vdpa_feature,
+	.set_vdpa_feature = virtio_vdpa_net_set_vdpa_feature,
 };
 


### PR DESCRIPTION
In virtio spec, GUEST_ANNOUNCE rely on ctrl vq, but current VFE didn't have ctrl vq, so, unmask it when set.

RM: 3827154