### PR TITLE
app/vfe-vdpa: set LimitNOFILE in systemd service

### DIFF
--- a/app/vfe-vdpa/vfe-vhostd.service.in
+++ b/app/vfe-vdpa/vfe-vhostd.service.in
@@ -6,6 +6,7 @@ After=network.target network.service networking.service
 Type=simple
 ExecStart=@prefix@/bin/vfe-vhostd -v --file-prefix=vfe-vhostd -a 0000:00:00.0 --log-level=.,debug --vfio-vf-token=cdc786f0-59d4-41d9-b554-fed36ff5e89f -- --client
 TimeoutSec=1800
+LimitNOFILE=200000
 LimitCORE=infinity
 KillSignal=SIGTERM
 Restart=always

--- a/app/virtio-ha/vfe-vhostd-ha.service.in
+++ b/app/virtio-ha/vfe-vhostd-ha.service.in
@@ -6,6 +6,7 @@ After=network.target network.service networking.service
 Type=simple
 ExecStart=@prefix@/bin/vfe-vhostd-ha
 TimeoutSec=1800
+LimitNOFILE=200000
 LimitCORE=infinity
 KillSignal=SIGTERM
 Restart=always


### PR DESCRIPTION
Without LimitNOFILE setting in vfe-vhostd.service, the default "Max open file" varies between systems.

With 2K devices, leave 100 open files for each. LimitNOFILE=200000 should be enough.

RM: 3872210