### PR TITLE
vdpa/virtio: remove flag of HA context remove

### DIFF
--- a/app/vfe-vdpa/main.c
+++ b/app/vfe-vdpa/main.c
@@ -343,8 +343,6 @@ void vdpa_with_socket_path_stop(const char *vf_name)
 		return;
 	}
 
-	rte_vdpa_vf_ctrl_ctx_remove(true);
-
 	if (vport->ifname[0] != '\0') {
 		close_vdpa(vport);
 		memset(vport, 0, sizeof(*vport));

--- a/app/vfe-vdpa/vdpa_rpc.c
+++ b/app/vfe-vdpa/vdpa_rpc.c
@@ -130,8 +130,6 @@ static cJSON *vdpa_pf_dev_remove(const char *pf_name)
 
 	virtio_ha_dev_lock();
 
-	rte_vdpa_pf_ctrl_ctx_remove(true);
-
 	ret = rte_vdpa_pf_dev_remove(pf_name);
 
 	virtio_ha_dev_unlock();

--- a/drivers/common/virtio_mi/lm.c
+++ b/drivers/common/virtio_mi/lm.c
@@ -85,7 +85,6 @@ TAILQ_HEAD(virtio_vdpa_mi_privs, virtio_vdpa_pf_priv) virtio_mi_priv_list =
 						TAILQ_HEAD_INITIALIZER(virtio_mi_priv_list);
 static pthread_mutex_t mi_priv_list_lock = PTHREAD_MUTEX_INITIALIZER;
 static struct virtio_ha_pf_drv_ctx cached_ctx;
-static bool ctx_remove_enabled;
 
 static struct virtio_admin_ctrl *
 virtio_vdpa_send_admin_command_split(struct virtadmin_ctl *avq,
@@ -1037,12 +1036,6 @@ virtio_vdpa_blk_dev_get_adminq_idx(struct virtio_vdpa_pf_priv *priv __rte_unused
 	return 0;
 }
 
-void
-rte_vdpa_pf_ctrl_ctx_remove(bool enable)
-{
-	ctx_remove_enabled = enable;
-}
-
 static struct virtio_vdpa_dev_ops virtio_vdpa_net_dev_ops = {
 	.get_required_features = virtio_vdpa_get_net_dev_required_features,
 	.get_adminq_idx = virtio_vdpa_net_dev_get_adminq_idx,
@@ -1213,8 +1206,7 @@ virtio_vdpa_mi_dev_remove(struct rte_pci_device *pci_dev)
 	pthread_mutex_unlock(&mi_priv_list_lock);
 
 	if (found) {
-		if (ctx_remove_enabled)
-			virtio_ha_pf_ctx_remove(&priv->pf_name);
+		virtio_ha_pf_ctx_remove(&priv->pf_name);
 		virtio_vdpa_admin_queue_free(priv);
 		virtio_pci_dev_reset(priv->vpdev,VIRTIO_VDPA_REMOVE_RESET_TIME_OUT);
 		virtio_pci_dev_free(priv->vpdev);

--- a/drivers/common/virtio_mi/version.map
+++ b/drivers/common/virtio_mi/version.map
@@ -23,7 +23,6 @@ DPDK_22 {
 	rte_vdpa_pf_dev_add;
 	rte_vdpa_pf_dev_remove;
 	rte_vdpa_get_pf_list;
-	rte_vdpa_pf_ctrl_ctx_remove;
 
 	local: *;
 };

--- a/drivers/common/virtio_mi/virtio_lm.h
+++ b/drivers/common/virtio_mi/virtio_lm.h
@@ -68,7 +68,5 @@ int
 rte_vdpa_pf_dev_remove(const char *pf_name);
 int
 rte_vdpa_get_pf_list(struct virtio_vdpa_pf_info *pf_info, int max_pf_num);
-void
-rte_vdpa_pf_ctrl_ctx_remove(bool enable);
 
 #endif /* _VIRTIO_LM_H_ */

--- a/drivers/vdpa/virtio/version.map
+++ b/drivers/vdpa/virtio/version.map
@@ -6,7 +6,6 @@ DPDK_22 {
 	rte_vdpa_get_vf_list;
 	rte_vdpa_get_vf_info;
 	rte_vdpa_vf_dev_debug;
-	rte_vdpa_vf_ctrl_ctx_remove;
 
 	local: *;
 };

--- a/drivers/vdpa/virtio/virtio_vdpa.h
+++ b/drivers/vdpa/virtio/virtio_vdpa.h
@@ -114,5 +114,4 @@ int virtio_vdpa_dirty_desc_get(struct virtio_vdpa_priv *priv, int qix, uint64_t 
 int virtio_vdpa_used_vring_addr_get(struct virtio_vdpa_priv *priv, int qix, uint64_t *used_vring_addr, uint32_t *used_vring_len);
 const struct rte_memzone * virtio_vdpa_dev_dp_map_get(struct virtio_vdpa_priv *priv, size_t len);
 uint64_t virtio_vdpa_gpa_to_hva(int vid, uint64_t gpa);
-void rte_vdpa_vf_ctrl_ctx_remove(bool enable);
 #endif /* _VIRTIO_VDPA_H_ */


### PR DESCRIPTION
The flag ctx_remove_enabled is designed for RPC remove and application quit, since now application quit will not call device remove, the flag is not needed anymore.