### PR TITLE
vdpa/virtio: fix dirty logging stop

### DIFF
--- a/drivers/vdpa/virtio/virtio_vdpa.h
+++ b/drivers/vdpa/virtio/virtio_vdpa.h
@@ -84,6 +84,7 @@ struct virtio_vdpa_priv {
 	bool fd_args_stored;
 	bool restore;
 	bool is_notify_thread_started;
+	bool log_started;
 	struct virtio_dev_name vf_name;
 	struct virtio_dev_name pf_name;
 };


### PR DESCRIPTION
When live migration fail on destination, source qemu will send stop logging(by `set_features`) to dpdk, virtio vdpa driver is missing sending this stop logging to controller. Start another round LM, the repeated start logging will cause controller return error and dpdk stuck in retry admin queue command.

Add log_started flag to save current logging state and send log stop to controller.

RM: 3851825