### PR TITLE
vdpa/virtio: re-implement iommu domain

### DIFF
--- a/drivers/vdpa/virtio/virtio_vdpa.h
+++ b/drivers/vdpa/virtio/virtio_vdpa.h
@@ -34,7 +34,6 @@ struct virtio_vdpa_iommu_domain {
 	struct virtio_vdpa_vf_drv_mem mem;
 	int container_ref_cnt;
 	int mem_tbl_ref_cnt;
-	pthread_mutex_t domain_lock;
 };
 
 struct virtio_vdpa_vring_info {
@@ -63,8 +62,8 @@ struct virtio_vdpa_priv {
 	const struct rte_memzone *state_mz; /* This is used to formmat state  at local */
 	const struct rte_memzone *state_mz_remote; /* This is used get state frome contoller */
 	const struct virtio_vdpa_device_callback *dev_ops;
-	struct virtio_vdpa_iommu_domain *iommu_domain;
 	pthread_t notify_tid;
+	int iommu_idx;
 	enum virtio_internal_status lm_status;
 	int state_size;
 	int vfio_container_fd;

--- a/lib/vhost/fd_man.c
+++ b/lib/vhost/fd_man.c
@@ -294,8 +294,10 @@ fdset_event_dispatch(void *arg)
 			wcb = pfdentry->wcb;
 			dat = pfdentry->dat;
 			pfdentry->busy = 1;
-			if (pfdentry->check_timeout)
+			if (pfdentry->check_timeout) {
+				vsock = (struct vhost_user_socket *)pfdentry->dat;
 				vsock->timeout_enabled = false;
+			}
 
 			pthread_mutex_unlock(&pfdset->fd_mutex);
 


### PR DESCRIPTION
This commit changes iommu domain list to an array and adds a new lock
array to protect the iommu domain. This re-implementation is for
improving the thread-safety of iommu domain.