### PR TITLE
vhost: fix server mode timeout mechanism

### DIFF
--- a/drivers/vdpa/virtio/virtio_vdpa.c
+++ b/drivers/vdpa/virtio/virtio_vdpa.c
@@ -1773,6 +1773,10 @@ virtio_vdpa_dev_mem_tbl_cleanup(struct rte_vdpa_device *vdev)
 			mem->regions[i].guest_phys_addr, mem->regions[i].size);
 		if (ret < 0)
 			DRV_LOG(ERR, "Failed to DMA unmap region %u: %s", i, vdev->device->name);
+
+		DRV_LOG(INFO, "DMA unmap region: GPA 0x%" PRIx64 ", HPA 0x%" PRIx64
+			", size 0x%" PRIx64 ".", mem->regions[i].guest_phys_addr,
+			mem->regions[i].host_phys_addr, mem->regions[i].size);
 	}
 	mem->nregions = 0;
 }

--- a/lib/vhost/fd_man.h
+++ b/lib/vhost/fd_man.h
@@ -19,7 +19,6 @@ struct fdentry {
 	void *dat;	/* fd context */
 	int busy;	/* whether this entry is being used in cb. */
 	bool check_timeout; /* whether to check connection timeout */
-	struct timeval timestamp; /* Timestamp value for timeout check */
 };
 
 struct fdset {


### PR DESCRIPTION
Before this commit, RPC vf add in the server mode can cause segfault and server mode timeout is not working. This commit fixes the issue.