### PR TITLE
app/vfe-vdpa: skip wait when VF not assigned to QEMU

### DIFF
--- a/drivers/common/virtio_ha/virtio_ha.h
+++ b/drivers/common/virtio_ha/virtio_ha.h
@@ -100,11 +100,16 @@ struct virtio_vdpa_dma_mem {
 	struct virtio_vdpa_mem_region regions[];
 };
 
+struct vdpa_vf_ctx_content {
+	bool vhost_fd_saved;
+    struct virtio_vdpa_dma_mem mem;
+};
+
 struct vdpa_vf_ctx {
     int vfio_container_fd;
     int vfio_group_fd;
     int vfio_device_fd;
-    struct virtio_vdpa_dma_mem mem;
+	struct vdpa_vf_ctx_content ctt;
 };
 
 struct virtio_ha_vf_dev {

--- a/drivers/vdpa/virtio/virtio_vdpa.c
+++ b/drivers/vdpa/virtio/virtio_vdpa.c
@@ -2375,7 +2375,7 @@ virtio_vdpa_dev_probe(struct rte_pci_driver *pci_drv __rte_unused,
 		 */
 		pthread_mutex_lock(&iommu_domain_locks[iommu_idx]);
 		if (iommu_domain->vfio_container_fd == -1) {
-			mem = &cached_ctx.ctx->mem;
+			mem = &cached_ctx.ctx->ctt.mem;
 			for (i = 0; i < mem->nregions; i++) {
 				iommu_domain->mem.regions[i].guest_phys_addr = mem->regions[i].guest_phys_addr;
 				iommu_domain->mem.regions[i].host_phys_addr = mem->regions[i].host_phys_addr;


### PR DESCRIPTION
This commit optimizes the VF restore wait time on skip wait when the VF is not assigned to QEMU.