### PR TITLE
app/virtio-ha: fix incorrect memcpy and error handling

### DIFF
--- a/app/vfe-vdpa/vdpa_ha.c
+++ b/app/vfe-vdpa/vdpa_ha.c
@@ -223,7 +223,7 @@ virtio_ha_client_dev_restore_vf(int total_vf)
 
 		ret = virtio_ha_vf_ctx_query(&vf_dev->vf_devargs.vf_name, &vf_dev->pf_name, &vf_ctx);
 		if (ret < 0) {
-			RTE_LOG(ERR, HA, "Failed to query vf ctx\n");
+			RTE_LOG(ERR, HA, "Failed to query vf ctx (ret %d)\n", ret);
 			pthread_mutex_unlock(&vf_restore_lock);
 			ret = -1;
 			goto err;
@@ -287,12 +287,18 @@ virtio_ha_client_dev_restore_vf(int total_vf)
 			}
 		}
 err_vf_ctx:
-		free(vf_ctx);
-		free(vf_dev);
+		if (vf_ctx) {
+			free(vf_ctx);
+			vf_ctx = NULL;
+		}
+err:
+		if (vf_dev) {
+			free(vf_dev);
+			vf_dev = NULL;
+		}
 		memset(&vf_info, 0, sizeof(struct vdpa_vf_params));
 	}
 
-err:
 	cleanup_restore_queue();
 	virtio_ha_prio_chnl_destroy();
 	return ret;

--- a/app/virtio-ha/main.c
+++ b/app/virtio-ha/main.c
@@ -281,7 +281,9 @@ ha_server_app_query_vf_ctx(struct virtio_ha_msg *msg)
 				vf_ctt->vhost_fd_saved = false;
 			else
 				vf_ctt->vhost_fd_saved = true;
-			memcpy((void *)&vf_ctt->mem, &vf_dev->vf_ctx.ctt.mem, msg->iov.iov_len - sizeof(bool));
+			vf_ctt->mem.nregions = vf_dev->vf_ctx.ctt.mem.nregions;
+			memcpy((void *)vf_ctt->mem.regions, vf_dev->vf_ctx.ctt.mem.regions,
+				vf_dev->vf_ctx.ctt.mem.nregions * sizeof(struct virtio_vdpa_mem_region));
 			msg->nr_fds = 3;
 			msg->fds[0] = vf_dev->vf_ctx.vfio_container_fd;
 			msg->fds[1] = vf_dev->vf_ctx.vfio_group_fd;

--- a/drivers/common/virtio_ha/virtio_ha.c
+++ b/drivers/common/virtio_ha/virtio_ha.c
@@ -839,6 +839,7 @@ virtio_ha_vf_ctx_query(struct virtio_dev_name *vf,
 	struct virtio_ha_vf_dev *vf_dev;
 	struct virtio_ha_vf_dev_list *vf_list;
 	struct virtio_ha_msg *msg;
+	struct vdpa_vf_ctx_content *ctt;
 	bool found = false;
 	int ret;
 
@@ -846,7 +847,7 @@ virtio_ha_vf_ctx_query(struct virtio_dev_name *vf,
 		;
 
 	if (!__atomic_load_n(&ipc_client_connected, __ATOMIC_RELAXED))
-		return 0;
+		return -2;
 
 	msg = virtio_ha_alloc_msg();
 	if (!msg) {
@@ -876,7 +877,10 @@ virtio_ha_vf_ctx_query(struct virtio_dev_name *vf,
 		return -1;
 	}
 
-	*ctx = malloc(sizeof(int) * 3 + msg->iov.iov_len);
+	ctt = (struct vdpa_vf_ctx_content *)msg->iov.iov_base;
+
+	*ctx = malloc(sizeof(struct vdpa_vf_ctx) +
+		ctt->mem.nregions * sizeof(struct virtio_vdpa_mem_region));
 	if (*ctx == NULL) {
 		HA_IPC_LOG(ERR, "Failed to alloc vf ctx");
 		return -1;			


### PR DESCRIPTION
This commit fixes incorrect memory copy in HA application and wrong error handling in vdpa application.

RM: 3936436