### PR TITLE
vdpa/virtio: fix VF IO_PAGE_FAULT during recovery

### DIFF
--- a/app/virtio-ha/main.c
+++ b/app/virtio-ha/main.c
@@ -514,6 +514,10 @@ ha_server_store_dma_tbl(struct virtio_ha_msg *msg)
 			}
 			memcpy(&vf_dev->vf_ctx.ctt.mem, mem, len);
 			HA_APP_LOG(INFO, "Stored vf %s DMA memory table:", vf_name->dev_bdf);
+			if (mem->nregions > 0)
+				vf_dev->vf_devargs.mem_tbl_set = true;
+			else
+				vf_dev->vf_devargs.mem_tbl_set = false;
 			for (i = 0; i < mem->nregions; i++) {
 				HA_APP_LOG(INFO, "Region %u: GPA 0x%" PRIx64 " HPA 0x%" PRIx64 " Size 0x%" PRIx64,
 					i, mem->regions[i].guest_phys_addr, mem->regions[i].host_phys_addr,
@@ -653,6 +657,7 @@ ha_server_remove_dma_tbl(struct virtio_ha_msg *msg)
 		if (!strcmp(vf_dev->vf_devargs.vf_name.dev_bdf, vf_name->dev_bdf)) {
 			mem = &vf_dev->vf_ctx.ctt.mem;
 			mem->nregions = 0;
+			vf_dev->vf_devargs.mem_tbl_set = false;
 			HA_APP_LOG(INFO, "Removed vf %s DMA memory table", vf_name->dev_bdf);
 			break;
 		}

--- a/drivers/common/virtio_ha/virtio_ha.c
+++ b/drivers/common/virtio_ha/virtio_ha.c
@@ -919,12 +919,12 @@ virtio_ha_vf_ctx_query(struct virtio_dev_name *vf,
 }
 
 int
-virtio_ha_pf_ctx_set(const struct virtio_dev_name *pf, const struct virtio_pf_ctx *ctx)
+virtio_ha_pf_ctx_set(const struct virtio_dev_name *pf, const struct virtio_pf_ctx *ctx, int num)
 {
 	if (!pf_ctx_cb || !pf_ctx_cb->set)
 		return -1;
 
-	pf_ctx_cb->set(pf, ctx);
+	pf_ctx_cb->set(pf, ctx, num);
 
 	return 0;
 }
@@ -941,12 +941,12 @@ virtio_ha_pf_ctx_unset(const struct virtio_dev_name *pf)
 }
 
 int
-virtio_ha_vf_ctx_set(const struct virtio_dev_name *vf, const struct vdpa_vf_ctx *ctx)
+virtio_ha_vf_ctx_set(const struct virtio_dev_name *vf, const struct vdpa_vf_ctx *ctx, int vf_cnt_vm)
 {
 	if (!vf_ctx_cb || !vf_ctx_cb->set)
 		return -1;
 
-	vf_ctx_cb->set(vf, ctx);
+	vf_ctx_cb->set(vf, ctx, vf_cnt_vm);
 
 	return 0;
 }
@@ -1410,6 +1410,11 @@ virtio_ha_vf_mem_tbl_store(const struct virtio_dev_name *vf,
 		}
 	}
 
+	if (mem->nregions > 0)
+		vf_dev->vf_devargs.mem_tbl_set = true;
+	else
+		vf_dev->vf_devargs.mem_tbl_set = false;
+
 	if (!__atomic_load_n(&ipc_client_connected, __ATOMIC_RELAXED))
 		return 0;
 	else
@@ -1444,6 +1449,7 @@ virtio_ha_vf_mem_tbl_remove(struct virtio_dev_name *vf,
 		if (!strcmp(vf_dev->vf_devargs.vf_name.dev_bdf, vf->dev_bdf)) {
 			mem = &vf_dev->vf_ctx.ctt.mem;
 			mem->nregions = 0;
+			vf_dev->vf_devargs.mem_tbl_set = false;
 			break;
 		}
 	}

--- a/drivers/common/virtio_ha/virtio_ha.h
+++ b/drivers/common/virtio_ha/virtio_ha.h
@@ -21,7 +21,7 @@
 
 struct virtio_dev_name;
 
-typedef void (*ctx_set_cb)(const struct virtio_dev_name *dev, const void *ctx);
+typedef void (*ctx_set_cb)(const struct virtio_dev_name *dev, const void *ctx, int vf_num_vm);
 typedef void (*ctx_unset_cb)(const struct virtio_dev_name *dev);
 typedef void (*fd_cb)(int fd, void *data);
 typedef void (*ver_time_set)(char *version, char *buildtime);
@@ -87,6 +87,7 @@ struct vdpa_vf_with_devargs {
     struct virtio_dev_name vf_name;
     char vhost_sock_addr[VDPA_MAX_SOCK_LEN];
     char vm_uuid[RTE_UUID_STRLEN];
+	bool mem_tbl_set;
 };
 
 struct virtio_vdpa_mem_region {
@@ -149,6 +150,7 @@ struct virtio_ha_vf_to_restore {
 	TAILQ_ENTRY(virtio_ha_vf_to_restore) next;
 	struct vdpa_vf_with_devargs vf_devargs;
 	struct virtio_dev_name pf_name;
+	int vf_cnt_vm; /* VF number in the same VM */
 };
 
 TAILQ_HEAD(virtio_ha_vf_restore_list, virtio_ha_vf_to_restore);
@@ -209,13 +211,13 @@ int virtio_ha_vf_ctx_query(struct virtio_dev_name *vf,
 	const struct virtio_dev_name *pf, struct vdpa_vf_ctx **ctx);
 
 /* App set PF context to PF driver */
-int virtio_ha_pf_ctx_set(const struct virtio_dev_name *pf, const struct virtio_pf_ctx *ctx);
+int virtio_ha_pf_ctx_set(const struct virtio_dev_name *pf, const struct virtio_pf_ctx *ctx, int num);
 
 /* App unset PF context from PF driver */
 int virtio_ha_pf_ctx_unset(const struct virtio_dev_name *pf);
 
 /* App set VF context to VF driver */
-int virtio_ha_vf_ctx_set(const struct virtio_dev_name *vf, const struct vdpa_vf_ctx *ctx);
+int virtio_ha_vf_ctx_set(const struct virtio_dev_name *vf, const struct vdpa_vf_ctx *ctx, int vf_cnt_vm);
 
 /* App unset VF context from VF driver */
 int virtio_ha_vf_ctx_unset(const struct virtio_dev_name *vf);

--- a/drivers/common/virtio_mi/lm.c
+++ b/drivers/common/virtio_mi/lm.c
@@ -1216,7 +1216,7 @@ virtio_vdpa_mi_dev_remove(struct rte_pci_device *pci_dev)
 }
 
 static void
-virtio_ha_pf_drv_ctx_set(const struct virtio_dev_name *pf, const void *ctx)
+virtio_ha_pf_drv_ctx_set(const struct virtio_dev_name *pf, const void *ctx, __rte_unused int num)
 {
 	const struct virtio_pf_ctx *pf_ctx = (const struct virtio_pf_ctx *)ctx;
 

--- a/drivers/vdpa/virtio/virtio_vdpa.h
+++ b/drivers/vdpa/virtio/virtio_vdpa.h
@@ -34,6 +34,7 @@ struct virtio_vdpa_iommu_domain {
 	struct virtio_vdpa_vf_drv_mem mem;
 	int container_ref_cnt;
 	int mem_tbl_ref_cnt;
+	int tbl_recover_cnt;
 };
 
 struct virtio_vdpa_vring_info {
@@ -80,6 +81,7 @@ struct virtio_vdpa_priv {
 	bool configured;
 	bool dev_conf_read;
 	bool mem_tbl_set;
+	bool tbl_recovering;
 	bool ctx_stored;
 	bool fd_args_stored;
 	bool restore;


### PR DESCRIPTION
When recovery, one VF could be detached from VM. Before this commit, in this case, the memory table will be unmapped because of no other VF is using the table. But the VFs that have not restored still need the memory table. This commit prevent the memory table from release when there are VFs that have not restored need to use the table.

RM: 3957706