### PR TITLE
vhost: fix null pointer reference of vdpa dev

### DIFF
--- a/lib/vhost/fd_man.c
+++ b/lib/vhost/fd_man.c
@@ -276,8 +276,11 @@ fdset_event_dispatch(void *arg)
 					time_passed = (time.tv_sec - vsock->timestamp.tv_sec) * 1e6;
 					time_passed = (time_passed + (time.tv_usec - vsock->timestamp.tv_usec)) * 1e-6;
 					if (time_passed > VHOST_SOCK_TIME_OUT) {
+						pthread_mutex_lock(&vsock->vdpa_dev_mutex);
 						vdpa_dev = vsock->vdpa_dev;
-						vdpa_dev->ops->mem_tbl_cleanup(vdpa_dev);
+						if (vdpa_dev)
+							vdpa_dev->ops->mem_tbl_cleanup(vdpa_dev);
+						pthread_mutex_unlock(&vsock->vdpa_dev_mutex);
 						vsock->timeout_enabled = false;
 					}
 				}

--- a/lib/vhost/vhost.h
+++ b/lib/vhost/vhost.h
@@ -125,6 +125,7 @@ struct vhost_user_socket {
 
 	uint64_t protocol_features;
 
+	pthread_mutex_t vdpa_dev_mutex;
 	struct rte_vdpa_device *vdpa_dev;
 
 	struct rte_vhost_device_ops const *notify_ops;


### PR DESCRIPTION
When reconnection thread access vdpa_dev in vsocket, it could be set to NULL in another thread, so this commit fixes the potential NULL pointer reference.

RM: 3959758