### PR TITLE
vdpa/virtio: remove HPA for memory table

### DIFF
--- a/app/vfe-vdpa/vdpa_ha.c
+++ b/app/vfe-vdpa/vdpa_ha.c
@@ -178,8 +178,10 @@ virtio_ha_client_dev_restore_pf(int *total_vf)
 			memset(vf_dev, 0, sizeof(struct virtio_ha_vf_to_restore));
 			memcpy(&vf_dev->vf_devargs, vf_list + j, sizeof(struct vdpa_vf_with_devargs));
 			memcpy(&vf_dev->pf_name, pf_list + i, sizeof(struct virtio_dev_name));
+			vf_dev->vm_ctx.tbl_in_use = vf_dev->vf_devargs.mem_tbl_in_use;
 			vf_dev->vm_ctx.vm_vf = 1;
-			vf_dev->vm_ctx.vm_tbl_vf = 1;
+			if (vf_dev->vf_devargs.mem_tbl_in_use)
+				vf_dev->vm_ctx.vm_tbl_vf = 1;
 			TAILQ_INSERT_TAIL(&rq.non_prio_q, vf_dev, next);
 		}
 
@@ -196,10 +198,10 @@ virtio_ha_client_dev_restore_pf(int *total_vf)
 				strncmp(v1->vf_devargs.vm_uuid, v2->vf_devargs.vm_uuid, RTE_UUID_STRLEN) == 0) {
 				v1->vm_ctx.vm_vf++;
 				v2->vm_ctx.vm_vf++;
-				if (v1->vf_devargs.mem_tbl_set && v2->vf_devargs.mem_tbl_set) {
-					v1->vm_ctx.vm_tbl_vf++;
+				if (v1->vf_devargs.mem_tbl_in_use)
 					v2->vm_ctx.vm_tbl_vf++;
-				}
+				if (v2->vf_devargs.mem_tbl_in_use)
+					v1->vm_ctx.vm_tbl_vf++;
 			}
 			tmp = TAILQ_NEXT(tmp, next);
 		}

--- a/app/virtio-ha/main.c
+++ b/app/virtio-ha/main.c
@@ -12,6 +12,7 @@
 #include <linux/vfio.h>
 #include <unistd.h>
 #include <syslog.h>
+#include <fcntl.h>
 #include <inttypes.h>
 #include <sys/time.h>
 
@@ -236,6 +237,7 @@ ha_server_app_query_vf_list(struct virtio_ha_msg *msg)
 	struct virtio_ha_pf_dev_list *list = &hs.pf_list;
 	struct virtio_ha_vf_dev_list *vf_list = NULL;
 	uint32_t nr_vf, i = 0;
+	int ret;
 
 	TAILQ_FOREACH(dev, list, next) {
 		if (!strcmp(dev->pf_name.dev_bdf, msg->hdr.bdf)) {
@@ -257,6 +259,23 @@ ha_server_app_query_vf_list(struct virtio_ha_msg *msg)
 
 	vf = (struct vdpa_vf_with_devargs *)msg->iov.iov_base;
 	TAILQ_FOREACH(vf_dev, vf_list, next) {
+		if (vf_dev->vhost_fd != -1) {
+			ret = fcntl(vf_dev->vhost_fd, F_SETFL, O_NONBLOCK);
+			if (ret) {
+				HA_APP_LOG(ERR, "Failed to set vhost fd to non-blocking mode");
+				vf_dev->vf_devargs.mem_tbl_in_use = true;
+			}  else {
+				char buffer;
+				ssize_t bytes_read = recv(vf_dev->vhost_fd, (void *)&buffer, sizeof(char), MSG_PEEK);
+				if (bytes_read == 0)
+					/* vhost socket is disconnected */
+					vf_dev->vf_devargs.mem_tbl_in_use = false;
+				else
+					vf_dev->vf_devargs.mem_tbl_in_use = true;
+			}
+		} else {
+			vf_dev->vf_devargs.mem_tbl_in_use = false;
+		}
 		memcpy(vf + i, &vf_dev->vf_devargs, sizeof(struct vdpa_vf_with_devargs));
 		i++;		
 	}
@@ -561,12 +580,12 @@ ha_server_store_dma_tbl(struct virtio_ha_msg *msg)
 			memcpy(&vf_dev->vf_ctx.ctt.mem, mem, len);
 			HA_APP_LOG(INFO, "Stored vf %s DMA memory table:", vf_name->dev_bdf);
 			if (mem->nregions > 0)
-				vf_dev->vf_devargs.mem_tbl_set = true;
+				vf_dev->vf_devargs.mem_tbl_in_use = true;
 			else
-				vf_dev->vf_devargs.mem_tbl_set = false;
+				vf_dev->vf_devargs.mem_tbl_in_use = false;
 			for (i = 0; i < mem->nregions; i++) {
-				HA_APP_LOG(INFO, "Region %u: GPA 0x%" PRIx64 " HPA 0x%" PRIx64 " Size 0x%" PRIx64,
-					i, mem->regions[i].guest_phys_addr, mem->regions[i].host_phys_addr,
+				HA_APP_LOG(INFO, "Region %u: GPA 0x%" PRIx64 " QEMU_VA 0x%" PRIx64 " Size 0x%" PRIx64,
+					i, mem->regions[i].guest_phys_addr, mem->regions[i].guest_user_addr,
 					mem->regions[i].size);
 			}
 			break;
@@ -703,7 +722,7 @@ ha_server_remove_dma_tbl(struct virtio_ha_msg *msg)
 		if (!strcmp(vf_dev->vf_devargs.vf_name.dev_bdf, vf_name->dev_bdf)) {
 			mem = &vf_dev->vf_ctx.ctt.mem;
 			mem->nregions = 0;
-			vf_dev->vf_devargs.mem_tbl_set = false;
+			vf_dev->vf_devargs.mem_tbl_in_use = false;
 			HA_APP_LOG(INFO, "Removed vf %s DMA memory table", vf_name->dev_bdf);
 			break;
 		}

--- a/drivers/common/virtio_ha/virtio_ha.c
+++ b/drivers/common/virtio_ha/virtio_ha.c
@@ -1411,9 +1411,9 @@ virtio_ha_vf_mem_tbl_store(const struct virtio_dev_name *vf,
 	}
 
 	if (mem->nregions > 0)
-		vf_dev->vf_devargs.mem_tbl_set = true;
+		vf_dev->vf_devargs.mem_tbl_in_use = true;
 	else
-		vf_dev->vf_devargs.mem_tbl_set = false;
+		vf_dev->vf_devargs.mem_tbl_in_use = false;
 
 	if (!__atomic_load_n(&ipc_client_connected, __ATOMIC_RELAXED))
 		return 0;
@@ -1449,7 +1449,7 @@ virtio_ha_vf_mem_tbl_remove(struct virtio_dev_name *vf,
 		if (!strcmp(vf_dev->vf_devargs.vf_name.dev_bdf, vf->dev_bdf)) {
 			mem = &vf_dev->vf_ctx.ctt.mem;
 			mem->nregions = 0;
-			vf_dev->vf_devargs.mem_tbl_set = false;
+			vf_dev->vf_devargs.mem_tbl_in_use = false;
 			break;
 		}
 	}

--- a/drivers/common/virtio_ha/virtio_ha.h
+++ b/drivers/common/virtio_ha/virtio_ha.h
@@ -89,11 +89,11 @@ struct vdpa_vf_with_devargs {
     struct virtio_dev_name vf_name;
     char vhost_sock_addr[VDPA_MAX_SOCK_LEN];
     char vm_uuid[RTE_UUID_STRLEN];
-	bool mem_tbl_set;
+	bool mem_tbl_in_use;
 };
 
 struct virtio_vdpa_mem_region {
-	uint64_t host_phys_addr;
+	uint64_t guest_user_addr;
 	uint64_t guest_phys_addr;
 	uint64_t size;
 };
@@ -146,6 +146,7 @@ struct virtio_ha_device_list {
 struct virtio_ha_vm_dev_ctx {
 	int vm_tbl_vf; /* Number of VFs belong to the same VM and use the DMA tbl */
 	int vm_vf; /* Number of VFs belong to the same VM and shares the same VFIO container */
+	bool tbl_in_use; /* The VF is using DMA tbl or not */
 };
 
 struct virtio_ha_dev_ctx_cb {

--- a/drivers/vdpa/virtio/virtio_vdpa.c
+++ b/drivers/vdpa/virtio/virtio_vdpa.c
@@ -792,12 +792,12 @@ virtio_vdpa_raw_vfio_dma_unmap(int container_fd, uint64_t gpa, uint64_t sz)
 }
 
 static int
-virtio_vdpa_dev_dma_unmap(int container_fd, uint64_t hpa, uint64_t hva, uint64_t gpa, uint64_t sz)
+virtio_vdpa_dev_dma_unmap(int container_fd, uint64_t gua, uint64_t hva, uint64_t gpa, uint64_t sz)
 {
 	int ret;
 
-	DRV_LOG(INFO, "DMA unmap region: HVA 0x%" PRIx64 ", " "GPA 0x%" PRIx64 ", HPA 0x%" PRIx64
-		", size 0x%" PRIx64 ".", hva, gpa, hpa, sz);
+	DRV_LOG(INFO, "DMA unmap region: HVA 0x%" PRIx64 ", " "GPA 0x%" PRIx64 ", QEMU_VA 0x%" PRIx64
+		", size 0x%" PRIx64 ".", hva, gpa, gua, sz);
 
 	if (hva == 0) {
 		/* This region is not mapped to DPDK process yet */
@@ -863,7 +863,7 @@ virtio_vdpa_dev_cleanup(int vid)
 		for (i = 0; i < iommu_domain->mem.nregions; i++) {
 			reg = &iommu_domain->mem.regions[i];
 			if (virtio_vdpa_dev_dma_unmap(priv->vfio_container_fd,
-				reg->host_phys_addr, reg->host_user_addr, reg->guest_phys_addr,
+				reg->guest_user_addr, reg->host_user_addr, reg->guest_phys_addr,
 				reg->size) < 0) {
 				DRV_LOG(ERR, "%s vdpa unmap DMA failed ret:%d",
 							priv->vdev->device->name, ret);
@@ -881,14 +881,14 @@ unlock:
 
 static inline int
 virtio_vdpa_find_mem_in_vhost(const struct virtio_vdpa_vf_drv_mem_region *key,
-	const struct rte_vhost_memory *mem, const uint64_t *hpa)
+	const struct rte_vhost_memory *mem)
 {
 	uint32_t i;
 	const struct rte_vhost_mem_region *reg;
 
 	for (i = 0; i < mem->nregions; i++) {
 		reg = &mem->regions[i];
-		if ((hpa[i] == key->host_phys_addr) &&
+		if ((reg->guest_user_addr == key->guest_user_addr) &&
 			(reg->guest_phys_addr == key->guest_phys_addr) &&
 			(reg->size == key->size))
 			return i;
@@ -899,14 +899,14 @@ virtio_vdpa_find_mem_in_vhost(const struct virtio_vdpa_vf_drv_mem_region *key,
 
 static inline int
 virtio_vdpa_find_mem_in_iommu_domain(const struct rte_vhost_mem_region *key,
-	const struct virtio_vdpa_vf_drv_mem *mem, const uint64_t hpa)
+	const struct virtio_vdpa_vf_drv_mem *mem)
 {
 	uint32_t i;
 	const struct virtio_vdpa_vf_drv_mem_region *reg;
 
 	for (i = 0; i < mem->nregions; i++) {
 		reg = &mem->regions[i];
-		if ((reg->host_phys_addr == hpa) &&
+		if ((reg->guest_user_addr == key->guest_user_addr) &&
 			(reg->guest_phys_addr == key->guest_phys_addr) &&
 			(reg->size == key->size))
 			return i;
@@ -926,7 +926,7 @@ virtio_vdpa_dev_store_mem_tbl(struct virtio_vdpa_priv *priv, struct virtio_vdpa_
 	mem->nregions = iommu_domain->mem.nregions;
 	for (i = 0; i < iommu_domain->mem.nregions; i++) {
 		mem->regions[i].guest_phys_addr = iommu_domain->mem.regions[i].guest_phys_addr;
-		mem->regions[i].host_phys_addr = iommu_domain->mem.regions[i].host_phys_addr;
+		mem->regions[i].guest_user_addr = iommu_domain->mem.regions[i].guest_user_addr;
 		mem->regions[i].size = iommu_domain->mem.regions[i].size;
 	}
 	/* Don't store memory table before virtio_ha_vf_devargs_fds_store() call */
@@ -944,7 +944,6 @@ virtio_vdpa_dev_set_mem_table(int vid)
 	struct rte_vhost_memory *cur_mem = NULL;
 	struct virtio_vdpa_vf_drv_mem_region *reg;
 	struct rte_vhost_mem_region *vhost_reg;
-	uint64_t host_phys_addrs[VIRTIO_VDPA_MAX_MEM_REGIONS];
 	struct virtio_vdpa_iommu_domain *iommu_domain;
 	struct rte_vdpa_device *vdev = rte_vhost_get_vdpa_device(vid);
 	struct virtio_vdpa_priv *priv =
@@ -973,16 +972,6 @@ virtio_vdpa_dev_set_mem_table(int vid)
 		return ret;
 	}
 
-	for (i = 0; i < cur_mem->nregions; i++) {
-		vhost_reg = &cur_mem->regions[i];
-		host_phys_addrs[i] = rte_mem_virt2phy((void *)(uintptr_t)vhost_reg->host_user_addr);
-		if (host_phys_addrs[i] == RTE_BAD_IOVA) {
-			DRV_LOG(ERR, "virt2phy translate failed");
-			free(cur_mem);
-			return -1;
-		}
-	}
-
 	pthread_mutex_lock(&iommu_domain_locks[priv->iommu_idx]);
 	iommu_domain = virtio_iommu_domains[priv->iommu_idx];
 	if (iommu_domain == NULL)
@@ -990,10 +979,10 @@ virtio_vdpa_dev_set_mem_table(int vid)
 	/* Unmap region does not exist in current */
 	for (i = 0; i < iommu_domain->mem.nregions; i++) {
 		reg = &iommu_domain->mem.regions[i];
-		ret = virtio_vdpa_find_mem_in_vhost(reg, cur_mem, host_phys_addrs);
+		ret = virtio_vdpa_find_mem_in_vhost(reg, cur_mem);
 		if (ret < 0) {
 			if (virtio_vdpa_dev_dma_unmap(priv->vfio_container_fd,
-				reg->host_phys_addr, reg->host_user_addr, reg->guest_phys_addr,
+				reg->guest_user_addr, reg->host_user_addr, reg->guest_phys_addr,
 				reg->size) < 0) {
 				DRV_LOG(ERR, "%s vdpa unmap redundant DMA failed ret:%d",
 							priv->vdev->device->name, ret);
@@ -1006,30 +995,30 @@ virtio_vdpa_dev_set_mem_table(int vid)
 				if (rte_vfio_container_set_dma_map(priv->vfio_container_fd,
 					reg->host_user_addr, reg->guest_phys_addr, reg->size) < 0)
 					DRV_LOG(ERR, "%s failed to set DPDK dma map: HVA 0x%" PRIx64", "
-					"GPA 0x%" PRIx64 ", HPA 0x%" PRIx64 ", size 0x%" PRIx64,
+					"GPA 0x%" PRIx64 ", QEMU_VA 0x%" PRIx64 ", size 0x%" PRIx64,
 					vdev->device->name, reg->host_user_addr, reg->guest_phys_addr,
-					reg->host_phys_addr, reg->size);
+					reg->guest_user_addr, reg->size);
 			}
 			DRV_LOG(INFO, "%s HVA 0x%" PRIx64", "
-			"GPA 0x%" PRIx64 ", HPA 0x%" PRIx64 ", size 0x%" PRIx64
+			"GPA 0x%" PRIx64 ", QEMU_VA 0x%" PRIx64 ", size 0x%" PRIx64
 			" exist in cur map",
 			vdev->device->name, reg->host_user_addr, reg->guest_phys_addr,
-			reg->host_phys_addr, reg->size);
+			reg->guest_user_addr, reg->size);
 		}
 	}
 
 	/* Map the region if it doesn't exist yet */
 	for (i = 0; i < cur_mem->nregions; i++) {
 		vhost_reg = &cur_mem->regions[i];
-		ret = virtio_vdpa_find_mem_in_iommu_domain(vhost_reg, &iommu_domain->mem, host_phys_addrs[i]);
+		ret = virtio_vdpa_find_mem_in_iommu_domain(vhost_reg, &iommu_domain->mem);
 		if (ret < 0) {
 			ret = rte_vfio_container_dma_map(priv->vfio_container_fd,
 				vhost_reg->host_user_addr, vhost_reg->guest_phys_addr,
 				vhost_reg->size);
 			DRV_LOG(INFO, "DMA map region %u: HVA 0x%" PRIx64 ", "
-				"GPA 0x%" PRIx64 ", HPA 0x%" PRIx64 ", size 0x%"
+				"GPA 0x%" PRIx64 ", QEMU_VA 0x%" PRIx64 ", size 0x%"
 				PRIx64 ".", i, vhost_reg->host_user_addr, vhost_reg->guest_phys_addr,
-				host_phys_addrs[i], vhost_reg->size);
+				vhost_reg->guest_user_addr, vhost_reg->size);
 			if (ret < 0) {
 				DRV_LOG(ERR, "%s DMA map failed ret:%d",
 							priv->vdev->device->name, ret);
@@ -1040,10 +1029,10 @@ virtio_vdpa_dev_set_mem_table(int vid)
 			/* The same region could have different HVA, keep the 1st HVA */
 			vhost_reg->host_user_addr = iommu_domain->mem.regions[ret].host_user_addr;
 			DRV_LOG(INFO, "%s HVA 0x%" PRIx64", "
-			"GPA 0x%" PRIx64 ", HPA 0x%" PRIx64 ", size 0x%" PRIx64
+			"GPA 0x%" PRIx64 ", QEMU_VA 0x%" PRIx64 ", size 0x%" PRIx64
 			" already mapped",
 			vdev->device->name, vhost_reg->host_user_addr, vhost_reg->guest_phys_addr,
-			host_phys_addrs[i], vhost_reg->size);
+			vhost_reg->guest_user_addr, vhost_reg->size);
 		}
 	}
 
@@ -1051,7 +1040,7 @@ virtio_vdpa_dev_set_mem_table(int vid)
 		vhost_reg = &cur_mem->regions[i];
 		iommu_domain->mem.regions[i].guest_phys_addr = vhost_reg->guest_phys_addr;
 		iommu_domain->mem.regions[i].host_user_addr = vhost_reg->host_user_addr;
-		iommu_domain->mem.regions[i].host_phys_addr = host_phys_addrs[i];
+		iommu_domain->mem.regions[i].guest_user_addr = vhost_reg->guest_user_addr;
 		iommu_domain->mem.regions[i].size = vhost_reg->size;
 	}
 
@@ -1820,13 +1809,32 @@ virtio_vdpa_dev_presetup_done(int vid)
 }
 
 static void
+cleanup_raw_mem_tbl(struct virtio_vdpa_iommu_domain *iommu_domain, const char *name)
+{
+	struct virtio_vdpa_vf_drv_mem *mem;
+	int ret;
+	uint32_t i;
+
+	mem = &iommu_domain->mem;
+	for (i = 0; i < mem->nregions; i++) {
+		ret = virtio_vdpa_raw_vfio_dma_unmap(iommu_domain->vfio_container_fd,
+			mem->regions[i].guest_phys_addr, mem->regions[i].size);
+		if (ret < 0)
+			DRV_LOG(ERR, "Failed to DMA unmap region %u: %s", i, name);
+
+		DRV_LOG(INFO, "DMA unmap region: GPA 0x%" PRIx64 ", QEMU_VA 0x%" PRIx64
+			", size 0x%" PRIx64 ".", mem->regions[i].guest_phys_addr,
+			mem->regions[i].guest_user_addr, mem->regions[i].size);
+	}
+	mem->nregions = 0;
+}
+
+static void
 virtio_vdpa_dev_mem_tbl_cleanup(struct rte_vdpa_device *vdev)
 {
 	struct virtio_vdpa_priv *priv =
 		virtio_vdpa_find_priv_resource_by_vdev(vdev);
-	struct virtio_vdpa_vf_drv_mem *mem;
 	struct virtio_vdpa_iommu_domain *iommu_domain;
-	uint32_t i;
 	int ret;
 
 	ret = virtio_ha_vf_mem_tbl_remove(&priv->vf_name, &priv->pf_name);
@@ -1854,20 +1862,8 @@ virtio_vdpa_dev_mem_tbl_cleanup(struct rte_vdpa_device *vdev)
 		iommu_domain->mem_tbl_ref_cnt--;
 		priv->mem_tbl_set = false;
 	}
-	if (iommu_domain->mem_tbl_ref_cnt == 0 && iommu_domain->tbl_recover_cnt == 0) {
-		mem = &iommu_domain->mem;
-		for (i = 0; i < mem->nregions; i++) {
-			ret = virtio_vdpa_raw_vfio_dma_unmap(iommu_domain->vfio_container_fd,
-				mem->regions[i].guest_phys_addr, mem->regions[i].size);
-			if (ret < 0)
-				DRV_LOG(ERR, "Failed to DMA unmap region %u: %s", i, vdev->device->name);
-
-			DRV_LOG(INFO, "DMA unmap region: GPA 0x%" PRIx64 ", HPA 0x%" PRIx64
-				", size 0x%" PRIx64 ".", mem->regions[i].guest_phys_addr,
-				mem->regions[i].host_phys_addr, mem->regions[i].size);
-		}
-		mem->nregions = 0;
-	}
+	if (iommu_domain->mem_tbl_ref_cnt == 0 && iommu_domain->tbl_recover_cnt == 0)
+		cleanup_raw_mem_tbl(iommu_domain, vdev->device->name);
 unlock:
 	pthread_mutex_unlock(&iommu_domain_locks[priv->iommu_idx]);
 }
@@ -2229,6 +2225,7 @@ virtio_vdpa_dev_probe(struct rte_pci_driver *pci_drv __rte_unused,
 	struct timeval start, end;
 	uint64_t time_used;
 	struct vdpa_vf_with_devargs vf_dev;
+	bool unmap_all = false;
 
 	if (!domain_init) {
 		for (i = 0; i < VIRTIO_VDPA_MAX_IOMMU_DOMAIN; i++) {
@@ -2325,7 +2322,7 @@ virtio_vdpa_dev_probe(struct rte_pci_driver *pci_drv __rte_unused,
 	priv->iommu_idx = iommu_idx;
 
 	if (!strcmp(cached_ctx.vf_name.dev_bdf, devname)) {
-		priv->restore = true;
+		priv->restore = cached_ctx.vm_ctx->tbl_in_use;
 		container_fd = cached_ctx.ctx->vfio_container_fd;
 		group_fd = cached_ctx.ctx->vfio_group_fd;
 		device_fd = cached_ctx.ctx->vfio_device_fd;
@@ -2338,16 +2335,18 @@ virtio_vdpa_dev_probe(struct rte_pci_driver *pci_drv __rte_unused,
 			mem = &cached_ctx.ctx->ctt.mem;
 			for (i = 0; i < mem->nregions; i++) {
 				iommu_domain->mem.regions[i].guest_phys_addr = mem->regions[i].guest_phys_addr;
-				iommu_domain->mem.regions[i].host_phys_addr = mem->regions[i].host_phys_addr;
+				iommu_domain->mem.regions[i].guest_user_addr = mem->regions[i].guest_user_addr;
 				iommu_domain->mem.regions[i].size = mem->regions[i].size;
 			}
 			iommu_domain->mem.nregions = mem->nregions;
 			iommu_domain->tbl_recover_cnt = cached_ctx.vm_ctx->vm_tbl_vf;
 			iommu_domain->cont_recover_cnt = cached_ctx.vm_ctx->vm_vf;
+			if (cached_ctx.vm_ctx->vm_tbl_vf == 0)
+				unmap_all = true;
 		}
 		iommu_domain->cont_recover_cnt--;
 		pthread_mutex_unlock(&iommu_domain_locks[iommu_idx]);
-		if (cached_ctx.ctx->ctt.mem.nregions != 0)
+		if (cached_ctx.ctx->ctt.mem.nregions != 0 && cached_ctx.vm_ctx->tbl_in_use)
 			priv->tbl_recovering = true;
 		priv->mem_tbl_set = false;
 		priv->fd_args_stored = true;
@@ -2426,6 +2425,12 @@ virtio_vdpa_dev_probe(struct rte_pci_driver *pci_drv __rte_unused,
 		DRV_LOG(ERR, "%s failed to alloc virito pci dev", devname);
 		rte_errno = rte_errno ? rte_errno : VFE_VDPA_ERR_ADD_VF_ALLOC;
 		goto error;
+	}
+
+	if (unmap_all) {
+		pthread_mutex_lock(&iommu_domain_locks[iommu_idx]);
+		cleanup_raw_mem_tbl(iommu_domain, devname);
+		pthread_mutex_unlock(&iommu_domain_locks[iommu_idx]);
 	}
 
 	if(stage1) {
@@ -2553,7 +2558,6 @@ virtio_vdpa_dev_probe(struct rte_pci_driver *pci_drv __rte_unused,
 			goto error;
 		}
 	}
-
 
 	pthread_mutex_lock(&priv_list_lock);
 	TAILQ_INSERT_TAIL(&virtio_priv_list, priv, next);

--- a/drivers/vdpa/virtio/virtio_vdpa.h
+++ b/drivers/vdpa/virtio/virtio_vdpa.h
@@ -17,7 +17,7 @@ enum {
 
 struct virtio_vdpa_vf_drv_mem_region {
 	uint64_t host_user_addr;
-	uint64_t host_phys_addr;
+	uint64_t guest_user_addr;
 	uint64_t guest_phys_addr;
 	uint64_t size;
 };

--- a/lib/vhost/vhost_user.c
+++ b/lib/vhost/vhost_user.c
@@ -1119,7 +1119,7 @@ vhost_user_mmap_region(struct virtio_net *dev,
 
 	/* Always use MAP_POPULATE as it's needed for virt2phys */
 	mmap_addr = mmap(NULL, mmap_size, PROT_READ | PROT_WRITE,
-			MAP_SHARED | MAP_POPULATE, region->fd, 0);
+			MAP_SHARED, region->fd, 0);
 
 	if (mmap_addr == MAP_FAILED) {
 		VHOST_LOG_CONFIG(ERR, "(%s) mmap failed (%s).\n", dev->ifname, strerror(errno));


### PR DESCRIPTION
Previously, we use HPA to handle corner case when vhostd and qemu crash at the same time, but to get HPA, we add a mmap flag MAP_POPULATE, which makes the mmap time very long. This commit removes the usage of HPA and let vhostd-ha to check vhost fd connection status to know if QEMU crashes or not. If QEMU crashed, vhostd cleanup the memory table on restart. Meanwhile, we also handle the case of device unplug, which will also leads to socket disconnect.

RM: 3958103