### PR TITLE
vhost: fix incorrect epoll remove

### DIFF
--- a/lib/vhost/fd_man.h
+++ b/lib/vhost/fd_man.h
@@ -41,7 +41,7 @@ void fdset_destroy(struct fdset *fdset);
 int fdset_add(struct fdset *pfdset, int fd,
 	fd_cb rcb, fd_cb wcb, void *dat, bool check_timeout);
 
-void fdset_del(struct fdset *pfdset, int fd);
+void fdset_del(struct fdset *pfdset, struct fdentry *pfdentry);
 
 int fdset_try_del(struct fdset *pfdset, int fd);
 


### PR DESCRIPTION
In some cases, QEMU socket may disconnect and connect again. Then vhost will close the fd the re-open a new one, it could be the same fd number. But after connect, vhost will epoll_ctl remove the fd, then incorrectly remove the new fd. This commit fixes this issue.