### PR TITLE
vdpa/virtio: Fix resource leak when dev close

### DIFF
--- a/drivers/vdpa/virtio/virtio_vdpa.c
+++ b/drivers/vdpa/virtio/virtio_vdpa.c
@@ -516,7 +516,12 @@ virtio_vdpa_dev_notifier(void *arg)
 
 	ret = rte_vhost_host_notifier_ctrl(priv->vid, RTE_VHOST_QUEUE_ALL, true);
 	if (ret) {
-		priv->doorbell_relay = true;
+		ret = rte_atomic16_cmpset(&priv->doorbell_relay, VIRTIO_VDPA_DOOR_BELL_INIT,
+					VIRTIO_VDPA_DOOR_BELL_RELAY);
+		if (!ret) {
+			return NULL;
+		}
+
 		DRV_LOG(ERR, "%s vid %d dev notifier thread failed use relay ret:%d",
 			priv->vdev->device->name, priv->vid, ret);
 
@@ -539,8 +544,6 @@ virtio_vdpa_dev_notifier(void *arg)
 		virtio_pci_dev_queue_notify(priv->vpdev, i);
 		rte_vhost_vring_call(priv->vid, i);
 	}
-
-	priv->is_notify_thread_started = false;
 
 	return NULL;
 }
@@ -1258,7 +1261,7 @@ virtio_vdpa_dev_close_work(void *arg)
 	int ret;
 
 	DRV_LOG(INFO, "%s vfid %d dev close work of lcore:%d start", priv->vdev->device->name, priv->vf_id, priv->lcore_id);
-	if (priv->is_notify_thread_started && (!priv->doorbell_relay)) {
+	if (priv->is_notify_thread_started) {
 		ret = pthread_join(priv->notify_tid, &status);
 		if (ret) {
 			DRV_LOG(ERR, "failed to join terminated notify_ctrl thread: %s", rte_strerror(ret));
@@ -1431,10 +1434,11 @@ virtio_vdpa_dev_close(int vid)
 		ret = pthread_cancel(priv->notify_tid);
 		if (ret) {
 			DRV_LOG(ERR, "failed to cancel notify_ctrl thread: %s",rte_strerror(ret));
-			priv->is_notify_thread_started = false;
 		}
 
-		if ((!ret) && priv->doorbell_relay) {
+		ret = rte_atomic16_cmpset(&priv->doorbell_relay, VIRTIO_VDPA_DOOR_BELL_INIT,
+					VIRTIO_VDPA_DOOR_BELL_CANCLE);
+		if (!ret) {
 			ret = pthread_join(priv->notify_tid, &status);
 			if (ret) {
 				DRV_LOG(ERR, "failed to join terminated notify_ctrl thread: %s", rte_strerror(ret));
@@ -1627,7 +1631,7 @@ virtio_vdpa_dev_config(int vid)
 	DRV_LOG(INFO, "%s vfid %d launch all vq notifier thread",
 			priv->vdev->device->name, priv->vf_id);
 	priv->is_notify_thread_started = false;
-	priv->doorbell_relay = false;
+	priv->doorbell_relay = VIRTIO_VDPA_DOOR_BELL_INIT;
 	ret = pthread_create(&priv->notify_tid, NULL,virtio_vdpa_dev_notifier, priv);
 	if (ret) {
 		DRV_LOG(ERR, "%s vfid %d failed launch notifier thread ret:%d",

--- a/drivers/vdpa/virtio/virtio_vdpa.h
+++ b/drivers/vdpa/virtio/virtio_vdpa.h
@@ -53,6 +53,9 @@ struct virtio_vdpa_vring_info {
 
 #define VIRTIO_VDPA_DRIVER_NAME vdpa_virtio
 
+#define VIRTIO_VDPA_DOOR_BELL_INIT 0
+#define VIRTIO_VDPA_DOOR_BELL_RELAY 1
+#define VIRTIO_VDPA_DOOR_BELL_CANCLE 2
 struct virtio_vdpa_priv {
 	TAILQ_ENTRY(virtio_vdpa_priv) next;
 	rte_uuid_t vm_uuid;
@@ -79,6 +82,7 @@ struct virtio_vdpa_priv {
 	uint64_t guest_features;
 	struct virtio_vdpa_vring_info **vrings;
 	uint16_t hw_nr_virtqs; /* Number of vq device supported */
+	volatile uint16_t doorbell_relay;
 	bool configured;
 	bool dev_conf_read;
 	bool mem_tbl_set;
@@ -87,7 +91,6 @@ struct virtio_vdpa_priv {
 	bool fd_args_stored;
 	bool restore;
 	bool is_notify_thread_started;
-	bool doorbell_relay;
 	bool log_started;
 	struct virtio_dev_name vf_name;
 	struct virtio_dev_name pf_name;


### PR DESCRIPTION
If thread didn't join, it will leak resource, fix by always do join, in dev close or in delay work