### PR TITLE
app/vfe-vdpa: support specify rpc server ip

### DIFF
--- a/app/vfe-vdpa/jsonrpc-c.c
+++ b/app/vfe-vdpa/jsonrpc-c.c
@@ -261,7 +261,6 @@ int jrpc_server_init(struct jrpc_server *server, int port_number)
 int jrpc_server_init_with_ev_loop(struct jrpc_server *server,
 	int port_number, struct ev_loop *loop)
 {
-	memset(server, 0, sizeof(struct jrpc_server));
 	server->loop = loop;
 	server->port_number = port_number;
 	char *debug_level_env = getenv("JRPC_DEBUG");
@@ -289,7 +288,7 @@ static int __jrpc_server_start(struct jrpc_server *server)
 	hints.ai_socktype = SOCK_STREAM;
 	hints.ai_flags = AI_PASSIVE; /* use my IP */
 
-	rv = getaddrinfo("localhost", PORT, &hints, &servinfo);
+	rv = getaddrinfo(server->ip, PORT, &hints, &servinfo);
 	if (rv) {
 		fprintf(stderr, "getaddrinfo: %s\n", gai_strerror(rv));
 		return 1;

--- a/app/vfe-vdpa/jsonrpc-c.h
+++ b/app/vfe-vdpa/jsonrpc-c.h
@@ -52,6 +52,7 @@ struct jrpc_server {
 	int procedure_count;
 	struct jrpc_procedure *procedures;
 	int debug_level;
+	const char *ip;
 };
 
 struct jrpc_connection {

--- a/app/vfe-vdpa/vdpa_rpc.h
+++ b/app/vfe-vdpa/vdpa_rpc.h
@@ -14,6 +14,8 @@
 #include "jsonrpc-c.h"
 
 #define MAX_IF_PATH_LEN 120
+#define MAX_SERVERIP_LEN 100
+
 /* VDPA RPC */
 #define VIRTNET_FEATURE_SZ	64
 #define MAX_VDPA_SAMPLE_PORTS 2048

--- a/app/vfe-vdpa/vhostmgmt
+++ b/app/vfe-vdpa/vhostmgmt
@@ -183,7 +183,6 @@ def version(args):
     print(json.dumps(result, indent=2))
 
 def main():
-    server_addr='127.0.0.1'
     server_port='12190'
     timeout=125.0
 
@@ -191,6 +190,9 @@ def main():
         description='Nvidia vhostd-rpc command line interface ' + __version__)
     subparsers = parser.add_subparsers(help='** Use -h for sub-command usage',
                                        dest='called_rpc_name')
+
+    parser.add_argument('-s', '--serverip', action='store', dest='serverip',
+                        default='127.0.0.1', help="server ip to connect to")
 
     # version
     p = subparsers.add_parser('version', help='show vhostd version info')
@@ -293,7 +295,7 @@ def main():
                 print("Error: invalid action.")
                 parser.print_usage()
                 sys.exit(1)
-    args.client = JsonRpcVirtnetClient(server_addr, server_port, timeout)
+    args.client = JsonRpcVirtnetClient(args.serverip, server_port, timeout)
     if hasattr(args, 'func'):
         try:
             call_rpc_func(args)


### PR DESCRIPTION
For service vfe-vhostd, add paramter --serverip=x.x.x.x to specify the server ip RPC listen on.

For rpc client vfe-vhost-cli, add paramter --serverip=x.x.x.x to specify RPC server ip to connect.

RM: 4049951