### PR TITLE
app/vfe-vdpa: Add adminq info dump

### DIFF
--- a/app/vfe-vdpa/vhostmgmt
+++ b/app/vfe-vdpa/vhostmgmt
@@ -139,6 +139,8 @@ def mgmtpf(args):
         params['dev'] = args.device
     if args.list_pf:
         params['list'] = args.list_pf
+        if args.debug_list_pf:
+            params['debug'] = args.debug_list_pf
 
     result = args.client.call('mgmtpf', params)
     print(json.dumps(result, indent=2))
@@ -204,6 +206,7 @@ def main():
     group.add_argument('-a', '--add', action='store_true', dest='add_pf', help="add a pci device")
     group.add_argument('-r', '--remove', action='store_true', dest='remove_pf', help="remove a pci device")
     group.add_argument('-l', '--list', action='store_true',  dest='list_pf', help="list all PF devices")
+    p.add_argument('-d', '--debug', action='store_true', dest='debug_list_pf', help="with debug info")
     p.add_argument(
         'device',
         metavar='DEVICE',

--- a/drivers/common/virtio_mi/lm.c
+++ b/drivers/common/virtio_mi/lm.c
@@ -1464,10 +1464,23 @@ rte_vdpa_get_pf_list(struct virtio_vdpa_pf_info *pf_info, int max_pf_num)
 {
 	struct virtio_vdpa_pf_info *info = pf_info;
 	struct virtio_vdpa_pf_priv *priv;
+	struct virtio_hw *hw;
+	struct virtadmin_ctl *avq;
+	struct virtqueue *vq;
 	int count = 0;
 
 	pthread_mutex_lock(&mi_priv_list_lock);
 	TAILQ_FOREACH(priv, &virtio_mi_priv_list, next) {
+		hw = &priv->vpdev->hw;
+		avq = hw->avq;
+		if (avq) {
+			vq = virtnet_aq_to_vq(hw->avq);
+			info->aq_desc = (uint64_t)vq->vq_split.ring.desc;
+			info->aq_avail = (uint64_t)vq->vq_split.ring.avail;
+			info->aq_used =  (uint64_t)vq->vq_split.ring.used;
+			info->aq_avail_idx =  vq->vq_split.ring.avail->idx;
+			info->aq_used_idx =  vq->vq_split.ring.used->idx;
+		}
 		rte_pci_device_name(&priv->pdev->addr, info->pf_name,
 				sizeof(info->pf_name));
 		count++;

--- a/drivers/common/virtio_mi/virtio_lm.h
+++ b/drivers/common/virtio_mi/virtio_lm.h
@@ -9,6 +9,11 @@ struct virtio_vdpa_pf_priv;
 
 struct virtio_vdpa_pf_info {
 	char pf_name[RTE_DEV_NAME_MAX_LEN];
+	uint64_t aq_desc;
+	uint64_t aq_avail;
+	uint64_t aq_used;
+	uint16_t aq_avail_idx;
+	uint16_t aq_used_idx;
 };
 
 __rte_internal int


### PR DESCRIPTION
Add parameter `-d` to dump admin queue info:

vfe-vhost-cli mgmtpf -l -d
{'list': True, 'debug': True}
{
  "devices": [
    {
      "pf": "0000:3b:00.2",
      "aq_desc": "0x17ffe4000",
      "aq_avail": "0x17ffe5000",
      "aq_used": "0x17ffe6000",
      "aq_avail_idx": "0",
      "aq_used_idx": "0"
    }
  ],
  "errno": 0,
  "errstr": "Success"
}