### PR TITLE
app/vfe-vdpa: fix RPC pending connections limit

### DIFF
--- a/app/vfe-vdpa/jsonrpc-c.c
+++ b/app/vfe-vdpa/jsonrpc-c.c
@@ -334,7 +334,7 @@ static int __jrpc_server_start(struct jrpc_server *server)
 
 	freeaddrinfo(servinfo); /* all done with this structure */
 
-	if (listen(sockfd, 5) == -1) {
+	if (listen(sockfd, 64) == -1) {
 		perror("listen");
 		exit(1);
 	}


### PR DESCRIPTION
For listen(int sockfd, int backlog), increase the pending connections from 5 to 64. So concurrent RPC request can be handled more quickly.

RM: 4176606