### PR TITLE
common/virtio_ha: sleep for HA close fd

### DIFF
--- a/drivers/common/virtio_ha/virtio_ha.c
+++ b/drivers/common/virtio_ha/virtio_ha.c
@@ -1288,7 +1288,7 @@ virtio_ha_vf_devargs_fds_remove(struct virtio_dev_name *vf,
 
 		virtio_ha_free_msg(msg);
 
-		return 0;
+		return 1;
 	}
 }
 

--- a/drivers/vdpa/virtio/virtio_vdpa.c
+++ b/drivers/vdpa/virtio/virtio_vdpa.c
@@ -2210,7 +2210,10 @@ virtio_vdpa_dev_do_remove(struct rte_pci_device *pci_dev, struct virtio_vdpa_pri
 
 	if (priv->fd_args_stored) {
 		ret = virtio_ha_vf_devargs_fds_remove(&priv->vf_name, &priv->pf_name);
-		if (ret < 0)
+		/* if messgage send successfully, wait 100ms for HA close fd */
+		if (ret > 0)
+			usleep(100 * 1000);
+		else if (ret < 0)
 			DRV_LOG(ERR, "Failed to remove vf devargs and fds: %s", priv->vf_name.dev_bdf);
 	}
 


### PR DESCRIPTION
The last close of vfio fd will let kernel driver issue a FLR on device. If message VIRTIO_HA_VF_REMOVE_DEVARG_VFIO_FDS send to HA successfuly, sleep 100ms for FLR handling.

RM: 4176606