### PR TITLE
vhost: fix vq->ring_addrs cleanup

### DIFF
--- a/lib/vhost/vhost_user.c
+++ b/lib/vhost/vhost_user.c
@@ -2055,6 +2055,8 @@ vhost_user_get_vring_base(struct virtio_net **pdev,
 
 	vring_invalidate(dev, vq);
 
+	memset(&vq->ring_addrs, 0, sizeof(vq->ring_addrs));
+
 	return RTE_VHOST_MSG_RESULT_REPLY;
 }
 


### PR DESCRIPTION
Need clean up vq->ring_addrs in vhost_user_get_vring_base, or this invalid value will set to vq->desc, and this invalid VQ will incorrectly restore to backend:

    vhost_user_set_vring_kick
        translate_ring_addresses
                vq->desc = ring_addr_to_vva(vq->ring_addrs.desc_user_addr);